### PR TITLE
Added initial documentation for run the dockerize command

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -53,8 +53,7 @@ Table Of Contents
 
     `Disdat Re-execution <#disdat-re-execution>`__ 13
 
-**`Dockerizor: The Disdat Container
-Compiler <#dockerizor-the-disdat-container-compiler>`__** **13**
+**`Dockerizer: The Disdat Container Compiler <#dockerizer-the-disdat-container-compiler>`__** **13**
 
     `Container Calling Convention <#container-calling-convention>`__ 13
 
@@ -558,4 +557,54 @@ Here we describe how Disdat uses hyperframes to implement bundles by
 encapsulating workflow outputs (production) and presenting bundles to
 user pipeline tasks through hyperframe interpretation.
 
+Dockerizer: The Disdat Container Compiler
+=========================================
 
+Disdat provides a `dockerize` command for creating self-contained Docker
+images of user-defined transforms. An image includes:
+
+- A base operating system installation (e.g., Ubuntu 16.04)
+- A full Disdat Python environment
+- Optional user-selected O/S-specific binary packages (e.g., `.deb` packages) and `pip`-managed Python packages
+- The user-defined transform
+
+Having created the image, the Disdat `run` command loads and executes the
+transform within the image on an input bundle. The user should first install
+the Docker platform before running the `dockerize` command.
+
+$ dsdt dockerize path/to/user/defined/transform/source/tree user.module.PipeClass
+$ dsdt run input_bundle output_bundle user.module.PipeClass
+
+
+Using the dockerizer to create images
+-------------------------------------
+
+Users create Docker images for their transforms using the `dockerize` command:
+
+dsdt dockerize [-h] [--config-dir CONFIG_DIR] [--os-type OS_TYPE]
+               [--os-version OS_VERSION] [--push] [--no-build]
+               pipe_root pipe_cls
+
+`pipe_root` specifies the root of the Python source tree containing the user-
+defined transform. The root of the tree must have a `setuptools`-style
+`setup.py` that, at the minimum, declares any external Python packages
+dependencies for the transform.
+
+`pipe_class` specifies the fully-qualified class name of the transform. The
+module and class name of the transform should follow standard Python naming
+conventions, i.e., the transform named `module.submodule.PipeClass` should
+be defined as `class PipeClass` in the file `module/submodule.py` under
+`pipe_root`.
+
+`--os-type` specifies the base operating system to install. If not specified,
+`dockerize` defaults to Ubuntu (which is the only O/S it currently supports).
+
+`--os-version` specifies the base O/S version to install. If not specified,
+`dockerize` defaults to 16.04.
+
+Given a transform named `module.submodule.PipeClass`, `dockerize` will create
+an image named `disdat-module-submodule[-submodule]`.
+
+If successful, `dockerize` will create a Docker image named
+`disdat-module-submodule`. Using the Docker (NOT Disdat) `run` command will
+display the help message for the image entry point script.

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(
         '': ['*.json'],
         'disdat': [
             'config/disdat/*',
+            'VERSION',
         ],
         'infrastructure': [
             'Dockerfiles/hyperframe_def/*'


### PR DESCRIPTION
This PR adds an initial description of the Disdat `dockerize` command. It also fixes a bug when installing the `VERSION` file through `python setup.py install`.