### PR TITLE
Fixes to returning dirs and example README

### DIFF
--- a/disdat/hyperframe.py
+++ b/disdat/hyperframe.py
@@ -439,6 +439,25 @@ def delete_hfr_db(engine_g, uuid=None, owner=None, human_name=None, processing_n
     return results
 
 
+def get_files_in_dir(dir):
+    """ Look for files in a user returned directory
+    1.) Only look one-level down (in this directory)
+    2.) Do not include anything that looks like one of disdat's pbufs
+
+    TODO: One place that defines the format of the Disdat pb file names
+    See data_context.DataContext: rebuild_db() *_frame.pb, *_hframe.pb, *_auth.pb
+    Args:
+        (str): local directory
+    Returns:
+        (list:str): List of files in that directory
+    """
+
+    files = [os.path.join(dir, f) for f in os.listdir(dir) if os.path.isfile(os.path.join(dir, f))
+             and ('_hframe.pb' not in f) and ('_frame.pb' not in f) and ('_auth.pb' not in f)]
+
+    return files
+
+
 def detect_local_fs_path(series):
     """
     Given a series, check whether all entries appear to be real paths and:
@@ -459,7 +478,8 @@ def detect_local_fs_path(series):
         if os.path.isfile(s):
             output.append("file://{}".format(os.path.abspath(s)))
         elif os.path.isdir(s):
-            output.extend(["file://{}".format(os.path.join(s,f)) for f in os.listdir(s) if os.path.isfile(os.path.join(s, f))])
+            """ Find files one-level down """
+            output.extend(["file://{}".format(os.path.join(s, f)) for f in get_files_in_dir(s)])
         else:
             del output
             return None

--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -414,7 +414,7 @@ class PipeTask(luigi.Task, PipeBase):
 
         """
 
-        kwargs = {}
+        kwargs = dict()
 
         # 1.) Place input hyperframe presentable into the users's run / requires function
         kwargs[CLOSURE_PIPE_INPUT] = self.presentable_inputs

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -175,10 +175,12 @@ Now all of your data is safely on S3.   To illustrate, let's delete our local co
 If you ``dsdt cat MNIST.data.gz`` you'll notice something interesting.   Your bundle now has a bunch of s3 paths!
 That's because Disdat leaves your data on S3 unless you really want it locally.   To localize:
 
+
 .. code-block:: console
     $ dsdt pull -b --localize MNIST.data.gz
 
-Now all of your data is also local. 
+
+Now all of your data is also local.
 
 
 

--- a/examples/README.rst
+++ b/examples/README.rst
@@ -40,11 +40,9 @@ broken the example down into three steps in ``pipelines/mnist.py``, which you wi
 
 * ``GetDataGz``: This downloads four gzip files and stores them in a bundle called ``MNIST.data.gz``
 
-* ``Train``: This PipeTask depends on the ``GetDataGz`` tasks, gets the gzip files, builds a Tensorflow graph and trains
-it. It stores the saved model into an output bundle called ``MNIST.trained``.
+* ``Train``: This PipeTask depends on the ``GetDataGz`` tasks, gets the gzip files, builds a Tensorflow graph and trains it.  It stores the saved model into an output bundle called ``MNIST.trained``.
 
-* ``Evaluate``: This PipeTask depends on both upstream tasks.  It rebuilds the graph, restores the values, and evaluates
-the model.  It returns a single accuracy float in it's output bundle ``MNIST.eval``
+* ``Evaluate``: This PipeTask depends on both upstream tasks.  It rebuilds the graph, restores the values, and evaluates the model.  It returns a single accuracy float in it's output bundle ``MNIST.eval``
 
 
 Dependencies
@@ -53,15 +51,13 @@ Dependencies
 A Disdat PipeTask consists of two functions: ``pipe_requires`` and ``pipe_run``.   If you know Luigi, these are analagous to
 `requires ``and ``run``.  Let's first describe what they do, and then we can describe how they are different from those analogs.
 
-* ``pipe_requires``: Here you declare the tasks that must run before this task.  To do so you write statements like:
-`self.add_dependency("input_gzs", GetDataGz, {})``.   This says that the current task needs a ``GetDataGz`` instance to run with no
-parameters.  It also says that Disdat should setup the output of that task as a named parameter to ``pipe_run`` called ``'input_gzs'``.
-Users may optionally name the output bundle in this function with ``set_bundle_name(<your name>)``.
+* ``pipe_requires``: Here you declare the tasks that must run before this task.  To do so you write statements like: ``self.add_dependency("input_gzs", GetDataGz, {})``.   This says that the current task needs a ``GetDataGz`` instance to run with no parameters.  It also says that Disdat should setup the output of that task as a named parameter to ``pipe_run`` called ``'input_gzs'``.
+
+  Users may optionally name the output bundle in this function with ``set_bundle_name(<your name>)``.
 
 * ``pipe_run``: Here you perform the task's main work.  This function gets a set of named parameters.
     - ``pipeline_input``:  This contains the *input* bundle data.
-    - <your dependency names>:  Disdat prepares named parameters for each upstream dependency.  The variable will be they
-same type as the upstream task returned.
+    - <your dependency names>:  Disdat prepares named parameters for each upstream dependency.  The variable will be they same type as the upstream task returned.
 
 
 Outputs
@@ -79,8 +75,7 @@ However, Disdat manages your output paths for you -- you just need to name the f
 To do so, you can:
 
 * Call ``self.create_output_file("my_results.txt")``: this returns a ``luigi.LocalTarget`` object.  You can open and write to it.
-* Call ``self.get_output_dir()``:  This returns a fully-qualified path to your bundle's output directory.  You can place files
-directly into this directory.
+* Call ``self.get_output_dir()``:  This returns a fully-qualified path to your bundle's output directory.  You can place files directly into this directory.
 
 When you're done making files, you need to return the file paths (if you want them to be in your output bundle).  You can return:
 
@@ -95,16 +90,15 @@ MNIST Pipeline
 ==============
 
 * In ``GetDataGz`` you'll notice that we keep track of the files we write, and we return a dictionary of name to path.
-* ``Train`` consumes that dictionary and produces a TensorFlow DataSet from those gzip files.  Note that TensorFlow's ``Saver`
-object just wants an output directory -- it's not very easy to get the names of those files it produced.  So we create an
-output sub-directory in line 190:
-```
-save_dir = os.path.join(self.get_output_dir(), 'MNIST')
-```
-And then we pass that directory as an element in our return dictionary.  Disdat will save all the files in that directory
-into our output bundle.
-* Finally ``Evaluate`` uses the gzip files and the model saved by ``Train``.   Since TensorFlow's ``Saver`` just wants a directory,
-we take the dirname of the first file in ``Train``'s output in line 233.
+* ``Train`` consumes that dictionary and produces a TensorFlow DataSet from those gzip files.  Note that TensorFlow's ``Saver`` object just wants an output directory -- it's not very easy to get the names of those files it produced.  So we create an output sub-directory in line 190:
+
+  .. code-block:: console
+
+    save_dir = os.path.join(self.get_output_dir(), 'MNIST')
+
+  And then we pass that directory as an element in our return dictionary.  Disdat will save all the files in that directory into our output bundle.
+
+* Finally ``Evaluate`` uses the gzip files and the model saved by ``Train``.   Since TensorFlow's ``Saver`` just wants a directory, we take the dirname of the first file in ``Train``'s output in line 233.
 
 Running the Pipeline
 ====================
@@ -169,16 +163,16 @@ is simply setting a flag that tells Disdat, hey, don't throw this away.
 Now all of your data is safely on S3.   To illustrate, let's delete our local copies and pull it back.
 
 .. code-block:: console
+
     $ dsdt rm --all MNI.*
     $ dsdt pull -b MNIST.eval; dsdt pull -b MNIST.data.gz; dsdt pull -b MNIST.trained
 
-If you ``dsdt cat MNIST.data.gz`` you'll notice something interesting.   Your bundle now has a bunch of s3 paths!
-That's because Disdat leaves your data on S3 unless you really want it locally.   To localize:
 
+If you ``dsdt cat MNIST.data.gz`` you'll notice something interesting.   Your bundle now has a bunch of s3 paths! That's because Disdat leaves your data on S3 unless you really want it locally.   To localize:
 
 .. code-block:: console
-    $ dsdt pull -b --localize MNIST.data.gz
 
+    $ dsdt pull -b --localize MNIST.data.gz
 
 Now all of your data is also local.
 

--- a/examples/pipelines/files.py
+++ b/examples/pipelines/files.py
@@ -70,6 +70,12 @@ class CreateFiles(PipeTask):
             with open(f, 'w') as of:
                 of.write("Output dir file test string {}".format(i))
 
+        # Create files inside the root directory -- make sure that we don't add our pb's
+        outputs['root_output_dir'] = output_dir
+        for i in range(int(self.num_dir_files)):
+            with open(os.path.join(output_dir, "root_dir_output_{}".format(i))) as of:
+                of.write("Root output dir file test string {}".format(i))
+
         # Point to a file that already exists anywhere in the FS
         outputs['pre-existing files'].append(os.path.abspath(__file__))
 

--- a/examples/pipelines/files.py
+++ b/examples/pipelines/files.py
@@ -57,24 +57,18 @@ class CreateFiles(PipeTask):
 
         # Create files using Luigi.Target class
         for i in range(int(self.num_luigi_files)):
-            target = self.create_output_file("lf_output_{}".format(i))
+            target = self.create_output_file("new_dir/lf_output_{}".format(i))
             outputs['luigi target files'].append(target)
             with target.open('w') as of:
                 of.write("Luigi file test string {}".format(i))
 
-        # Create files directly inside this output bundle
+        # Create files directly inside output bundle dir, simply pass output dir in outputs
         output_dir = self.get_output_dir()
+        outputs['output directory files'].append(output_dir)
         for i in range(int(self.num_dir_files)):
             f = os.path.join(output_dir, "dir_output_{}".format(i))
-            outputs['output directory files'].append(f)
             with open(f, 'w') as of:
                 of.write("Output dir file test string {}".format(i))
-
-        # Create files inside the root directory -- make sure that we don't add our pb's
-        outputs['root_output_dir'] = output_dir
-        for i in range(int(self.num_dir_files)):
-            with open(os.path.join(output_dir, "root_dir_output_{}".format(i))) as of:
-                of.write("Root output dir file test string {}".format(i))
 
         # Point to a file that already exists anywhere in the FS
         outputs['pre-existing files'].append(os.path.abspath(__file__))


### PR DESCRIPTION
Features:

- Now strip annoying 'file://' when presenting the bundle with local files frames. 
- Updated examples/pipelines/files.py to show how you can return a directory to include output files.

Fixes:

-  Ensure Disdat .pb files not included when looking at user-returned directory for files to place in bundle
- Numerous formatting issues in examples/README