### PR TITLE
Added ignore_code_version option in configuration

### DIFF
--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -234,8 +234,12 @@ def different_code_versions(code_version, lineage_obj):
 
     """
 
+    conf = common.DisdatConfig.instance()
+
     # If there were uncommitted changes, then we have to re-run, mark as different
     if code_version.dirty:
+        if conf.ignore_code_version:
+            return False
         return True
 
     if code_version.semver != lineage_obj.pb.code_semver:

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -141,10 +141,11 @@ class DisdatConfig(object):
         """
 
         _logger.debug("Loading config file [{}]".format(disdat_config_file))
-        config = ConfigParser.SafeConfigParser({'meta_dir_root': self.meta_dir_root})
+        config = ConfigParser.SafeConfigParser({'meta_dir_root': self.meta_dir_root, 'ignore_code_version': 'False'})
         config.read(disdat_config_file)
         self.meta_dir_root = os.path.expanduser(config.get('core', 'meta_dir_root'))
         self.meta_dir_root = DisdatConfig._fix_relative_path(disdat_config_file, self.meta_dir_root)
+        self.ignore_code_version = config.getboolean('core', 'ignore_code_version')
 
         try:
             self.logging_config = os.path.expanduser(config.get('core', 'logging_conf_file'))

--- a/disdat/config/disdat/disdat.cfg
+++ b/disdat/config/disdat/disdat.cfg
@@ -1,5 +1,6 @@
 [core]
 logging_conf_file=logging.conf
+ignore_code_version=False
 
 [docker]
 


### PR DESCRIPTION
Users can opt out of re-running when we notice different git hashes.
1.) Adds a new option in core: ignore_code_version, which defaults to False.   
This means that the re-execution logic will check to see if the code has changed and re-run.  
2.) Users can set this to True, so that they may develop their pipelines but also re-use results so that their entire pipeline doesn't rerun simply because they haven't committed their code locally. 
