### PR TITLE
Fix AWS credential issue and optimize Docker image size

### DIFF
--- a/disdat/config/disdat/disdat.cfg
+++ b/disdat/config/disdat/disdat.cfg
@@ -20,8 +20,8 @@ ignore_code_version=False
 # ecr_login =
 
 [dockerize]
-os_type = ubuntu
-os_version = 16.04
+os_type = python
+os_version = 2.7.14-slim
 
 [run]
 # For AWS Batch: A job queue

--- a/disdat/dockerize.py
+++ b/disdat/dockerize.py
@@ -14,16 +14,19 @@
 # limitations under the License.
 #
 
-import disdat.common
-import disdat.resources
-import disdat.utility.aws_s3 as aws
-import docker
-import infrastructure.dockerizer
+# Built-in imports
 import inspect
 import logging
 import os
 import subprocess
 import tempfile
+
+# Third-party imports
+import disdat.common
+import disdat.resources
+import disdat.utility.aws_s3 as aws
+import docker
+import infrastructure.dockerizer
 
 _MODULE_NAME = inspect.getmodulename(__file__)
 
@@ -119,6 +122,47 @@ def dockerize(disdat_config, pipeline_root, pipeline_class_name, config_dir=None
                 raise RuntimeError(line)
             else:
                 print line
+
+
+def add_arg_parser(parsers):
+    dockerize_p = parsers.add_parser('dockerize', description="Dockerizer a particular transform.")
+    dockerize_p.add_argument(
+        '--config-dir',
+        type=str,
+        default=None,
+        help="A directory containing configuration files for the operating system within the Docker image",
+    )
+    dockerize_p.add_argument(
+        '--os-type',
+        type=str,
+        default=None,
+        help='The base operating system type for the Docker image',
+    )
+    dockerize_p.add_argument(
+        '--os-version',
+        type=str,
+        default=None,
+        help='The base operating system version for the Docker image',
+    )
+    dockerize_p.add_argument(
+        '--push',
+        action='store_true',
+        help="Push the image to a remote Docker registry (default is to not push; must set 'docker_registry' in Disdat config)",
+    )
+    dockerize_p.add_argument(
+        '--no-build',
+        action='store_false',
+        help='Do not build an image (only copy files into the Docker build context)',
+        dest='build',
+    )
+    dockerize_p.add_argument(
+        "pipe_root",
+        type=str,
+        help="Root of the Python source tree containing the user-defined transform; must have a setuptools-style setup.py file"
+    )
+    dockerize_p.add_argument("pipe_cls", type=str, help="User-defined transform, e.g., module.PipeClass")
+    dockerize_p.set_defaults(func=lambda args: main(disdat.common.DisdatConfig.instance(), args))
+    return parsers
 
 
 def main(disdat_config, args):

--- a/disdat/dsdt.py
+++ b/disdat/dsdt.py
@@ -50,24 +50,6 @@ def _apply(args):
     apply.main(DisdatConfig.instance(), args)
 
 
-def _dockerize(args):
-    """
-
-    :param args:
-    :return:
-    """
-    dockerize.main(DisdatConfig.instance(), args)
-
-
-def _run(args):
-    """
-
-    :param args:
-    :return:
-    """
-    run.main(DisdatConfig.instance, args)
-
-
 def main():
     """
     Main as a function for testing convenience and as a package entry point.
@@ -75,7 +57,7 @@ def main():
     :return: (shape of input df, shape of pushed df)
     """
 
-    if getattr( sys, 'frozen', False ) :
+    if getattr(sys, 'frozen', False):
         here = os.path.join(sys._MEIPASS, 'disdat')
     else:
         here = os.path.abspath(os.path.dirname(__file__))
@@ -101,49 +83,11 @@ def main():
     ls_p = subparsers.add_parser('init')
     ls_p.set_defaults(func=lambda args: DisdatConfig.init())
 
-    # autodock
-    dockerize_p = subparsers.add_parser('dockerize', description="Dockerizer a particular transform.")
-    dockerize_p.add_argument(
-        '--config-dir',
-        type=str,
-        default=None,
-        help="A directory containing configuration files for the operating system within the Docker image",
-    )
-    dockerize_p.add_argument('--os-type', type=str, default=None, help='The base operating system type for the Docker image')
-    dockerize_p.add_argument('--os-version', type=str, default=None, help='The base operating system version for the Docker image')
-    dockerize_p.add_argument(
-        '--push',
-        action='store_true',
-        help="Push the image to a remote Docker registry (default is to not push; must set 'docker_registry' in Disdat config)",
-    )
-    dockerize_p.add_argument(
-        '--no-build',
-        action='store_false',
-        help='Do not build an image (only copy files into the Docker build context)',
-        dest='build',
-    )
-    dockerize_p.add_argument(
-        "pipe_root",
-        type=str,
-        help="Root of the Python source tree containing the user-defined transform; must have a setuptools-style setup.py file"
-    )
-    dockerize_p.add_argument("pipe_cls", type=str, help="User-defined transform, e.g., module.PipeClass")
-    dockerize_p.set_defaults(func=lambda args: _dockerize(args))
+    # dockerize
+    subparsers = dockerize.add_arg_parser(subparsers)
 
     # run
-    run_p = subparsers.add_parser('run', description="Run containerized version of transform.")
-    run_p.add_argument('--backend', default=run.Backend.default(), type=str, choices=run.Backend.options(), help='An optional batch execution back-end to use')
-    run_p.add_argument("--force", action='store_true', help="If there are dependencies, force re-computation.")
-    run_p.add_argument("--no-push-input", action='store_false', help="Do not push the current committed input bundle before execution (default is to push)", dest='push_input_bundle')
-    run_p.add_argument('-it', '--input-tag', nargs=1, type=str, action='append',
-                       help="Input bundle tags: '-it authoritative:True -it version:0.7.1'")
-    run_p.add_argument('-ot', '--output-tag', nargs=1, type=str, action='append',
-                       help="Output bundle tags: '-ot authoritative:True -ot version:0.7.1'")
-    run_p.add_argument("input_bundle", type=str, help="Name of source data bundle.  '-' means no input bundle.")
-    run_p.add_argument("output_bundle", type=str, help="Name of destination bundle.  '-' means default output bundle.")
-    run_p.add_argument("pipe_cls", type=str, help="User-defined transform, e.g., module.PipeClass")
-    run_p.add_argument("pipeline_args", type=str,  nargs=argparse.REMAINDER, help="Optional set of parameters for this pipe '--parameter value'")
-    run_p.set_defaults(func=lambda args: _run(args))
+    subparsers = run.add_arg_parser(subparsers)
 
     # apply
     apply_p = subparsers.add_parser('apply', description="Apply a transform to an input bundle to produce an output bundle.")

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -37,23 +37,24 @@ It will then need to run it remotely.   Thus we need to submit a job.
 author: Kenneth Yocum
 """
 
-from disdat.pipe_base import PipeBase
-import disdat.constants as constants
-from disdat.hyperframe import FrameRecord
-import disdat.hyperframe_pb2 as hyperframe_pb2
+# Built-in imports
+import argparse
+
+# Third-party imports
+import boto3_session_cache as b3
 import disdat.fs as fs
 import disdat.common as common
 import disdat.utility.aws_s3 as aws
-import luigi
-from luigi import retcodes, build
-import boto3_session_cache as b3
 import docker
 import inspect
 import logging
+import luigi
 import os
 import time
-
+from disdat.common import DisdatConfig
+from disdat.pipe_base import PipeBase
 from enum import Enum
+from luigi import build
 
 _MODULE_NAME = inspect.getmodulename(__file__)
 
@@ -98,6 +99,7 @@ class RunTask(luigi.Task, PipeBase):
     backend = luigi.EnumParameter(enum=Backend, default=Backend.default())
     force = luigi.BoolParameter(default=False)
     push_input_bundle = luigi.BoolParameter(default=True)
+    aws_session_token_duration = luigi.IntParameter(default=0)
     input_tags = luigi.DictParameter()
     output_tags = luigi.DictParameter()
 
@@ -184,17 +186,28 @@ class RunTask(luigi.Task, PipeBase):
             input_bundle=self.input_bundle,
             output_bundle=self.output_bundle,
             pipeline_class_name=self.pipeline_class_name,
-            pipeline_params=list(self.pipeline_params), # for some reason ListParameter is creating a tuple
+            pipeline_params=list(self.pipeline_params),  # for some reason ListParameter is creating a tuple
             backend=self.backend,
             force=bool(self.force),
             push_input_bundle=bool(self.push_input_bundle),
+            aws_session_token_duration=self.aws_session_token_duration,
             input_tags=self.input_tags,
             output_tags=self.output_tags
         )
 
 
-def _run(input_bundle, output_bundle, pipeline_params, pipeline_class_name,
-         backend=Backend.Local, force=False, push_input_bundle=True, input_tags=None, output_tags=None):
+def _run(
+    input_bundle,
+    output_bundle,
+    pipeline_params,
+    pipeline_class_name,
+    backend=Backend.Local,
+    force=False,  # @UnusedVariable
+    push_input_bundle=True,
+    aws_session_token_duration=0,
+    input_tags=None,
+    output_tags=None
+):
     """Run the dockerized version of a pipeline.
 
     Args:
@@ -213,10 +226,8 @@ def _run(input_bundle, output_bundle, pipeline_params, pipeline_class_name,
         `None`
     """
 
-    #print "_run args are {}".format(pipeline_params)
-
+    disdat_config = DisdatConfig.instance()
     pfs = fs.DisdatFS()
-    disdat_config = common.DisdatConfig.instance()
 
     pipeline_image_name = common.make_pipeline_image_name(pipeline_class_name)
 
@@ -270,6 +281,19 @@ def _run(input_bundle, output_bundle, pipeline_params, pipeline_class_name,
         # have to write special code of our own to deal with authenticating
         # with AWS.
         client = b3.client('batch', region_name=aws.profile_get_region())
+        # A bigger problem might be that the IAM role executing the job on
+        # a batch EC2 instance might not have access to the S3 remote. To
+        # get around this, allow the user to create some temporary AWS
+        # credentials.
+        if aws_session_token_duration > 0:
+            sts_client = b3.client('sts')
+            token = sts_client.get_session_token(DurationSeconds=aws_session_token_duration)
+            credentials = token['Credentials']
+            container_overrides['environment'] = [
+                {'name': 'AWS_ACCESS_KEY_ID', 'value': credentials['AccessKeyId']},
+                {'name': 'AWS_SECRET_ACCESS_KEY', 'value': credentials['SecretAccessKey']},
+                {'name': 'AWS_SESSION_TOKEN', 'value': credentials['SessionToken']}
+            ]
         job = client.submit_job(jobName=job_name, jobDefinition=job_definition, jobQueue=job_queue,
                                 containerOverrides=container_overrides)
         status = job['ResponseMetadata']['HTTPStatusCode']
@@ -292,7 +316,7 @@ def _run(input_bundle, output_bundle, pipeline_params, pipeline_class_name,
         if push_input_bundle:
             result = pfs.push(human_name=input_bundle)
             if result is None:
-                _logger.error("'run' failed trying to push input bundle {} to remote (bundle not committed?).".format(input_bundle))
+                _logger.error("'run' failed to push input bundle {} to remote (bundle not committed?).".format(input_bundle))
                 return
         # Now try to run the container
         try:
@@ -302,7 +326,8 @@ def _run(input_bundle, output_bundle, pipeline_params, pipeline_class_name,
             print "run.py ARGS {}".format(args)
 
             _logger.debug('Running image {} with arguments {}'.format(pipeline_image_name, args))
-            stdout = client.containers.run(pipeline_image_name, args, detach=False, environment=environment, init=True, stderr=True, volumes=volumes)
+            stdout = client.containers.run(pipeline_image_name, args, detach=False,
+                                           environment=environment, init=True, stderr=True, volumes=volumes)
             print stdout
         except docker.errors.ImageNotFound:
             _logger.error("Unable to find the docker image {}".format(pipeline_image_name))
@@ -313,7 +338,40 @@ def _run(input_bundle, output_bundle, pipeline_params, pipeline_class_name,
         raise ValueError('Got unrecognized job backend \'{}\': Expected {}'.format(backend, Backend.options()))
 
 
-def main(disdat_config, args):
+def add_arg_parser(parsers):
+    run_p = parsers.add_parser('run', description="Run a containerized version of transform.")
+    run_p.add_argument(
+        '--backend',
+        default=Backend.default(),
+        type=str,
+        choices=Backend.options(),
+        help='An optional batch execution back-end to use',
+    )
+    run_p.add_argument("--force", action='store_true', help="If there are dependencies, force re-computation.")
+    run_p.add_argument("--no-push-input", action='store_false',
+                       help="Do not push the current committed input bundle before execution (default is to push)", dest='push_input_bundle')
+    run_p.add_argument(
+        '--use-aws-session-token',
+        nargs=1,
+        default=[0],
+        type=int,
+        help='Use a temporary AWS session token to access the remote, valid for AWS_SESSION_TOKEN_DURATION seconds',
+        dest='aws_session_token_duration',
+    )
+    run_p.add_argument('-it', '--input-tag', nargs=1, type=str, action='append',
+                       help="Input bundle tags: '-it authoritative:True -it version:0.7.1'")
+    run_p.add_argument('-ot', '--output-tag', nargs=1, type=str, action='append',
+                       help="Output bundle tags: '-ot authoritative:True -ot version:0.7.1'")
+    run_p.add_argument("input_bundle", type=str, help="Name of source data bundle.  '-' means no input bundle.")
+    run_p.add_argument("output_bundle", type=str, help="Name of destination bundle.  '-' means default output bundle.")
+    run_p.add_argument("pipe_cls", type=str, help="User-defined transform, e.g., module.PipeClass")
+    run_p.add_argument("pipeline_args", type=str,  nargs=argparse.REMAINDER,
+                       help="Optional set of parameters for this pipe '--parameter value'")
+    run_p.set_defaults(func=lambda args: main(DisdatConfig.instance(), args))
+    return parsers
+
+
+def main(disdat_config, args):  # @UnusedVariable
     """Convert cli args into luigi task and params and execute
 
     Args:
@@ -340,16 +398,18 @@ def main(disdat_config, args):
     input_tags = common.parse_args_tags(args.input_tag)
     output_tags = common.parse_args_tags(args.output_tag)
 
-    task_args = [args.input_bundle,
-                 args.output_bundle,
-                 args.pipe_cls,
-                 args.pipeline_args,
-                 backend,
-                 args.force,
-                 args.push_input_bundle,
-                 input_tags,
-                 output_tags
-                 ]
+    task_args = [
+        args.input_bundle,
+        args.output_bundle,
+        args.pipe_cls,
+        args.pipeline_args,
+        backend,
+        args.force,
+        args.push_input_bundle,
+        args.aws_session_token_duration[0],
+        input_tags,
+        output_tags
+    ]
 
     commit_pipe = RunTask(*task_args)
 

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -292,7 +292,7 @@ def _run(input_bundle, output_bundle, pipeline_params, pipeline_class_name,
         if push_input_bundle:
             result = pfs.push(human_name=input_bundle)
             if result is None:
-                _logger.error("'run' failed trying to push input bundle {} to remote.".format(input_bundle))
+                _logger.error("'run' failed trying to push input bundle {} to remote (bundle not committed?).".format(input_bundle))
                 return
         # Now try to run the container
         try:

--- a/docs/dockerize.rst
+++ b/docs/dockerize.rst
@@ -4,7 +4,7 @@
 Disdat provides a ``dockerize`` command for creating self-contained Docker
 images of user-defined transforms. An image includes:
 
-- A base operating system installation (e.g., Ubuntu 16.04)
+- A base operating system installation (e.g., Python 2.7.14 over Ubuntu, or Ubuntu 16.04)
 - A full Disdat Python environment
 - Optional user-selected O/S-specific binary packages (e.g., `.deb` packages) and `pip`-managed Python packages
 - The user-defined transform
@@ -41,10 +41,10 @@ be defined as `class PipeClass` in the file `module/submodule.py` under
 `pipe_root`.
 
 `--os-type` specifies the base operating system to install. If not specified,
-``dockerize`` defaults to Ubuntu (which is the only O/S it currently supports).
+``dockerize`` defaults to a Python installation over Ubuntu.
 
 `--os-version` specifies the base O/S version to install. If not specified,
-``dockerize`` defaults to 16.04.
+``dockerize`` defaults to Python 2.7.14-slim.
 
 Given a transform named `module.submodule.PipeClass`, ``dockerize`` will create
 an image named `disdat-module-submodule[-submodule]`.

--- a/docs/run.rst
+++ b/docs/run.rst
@@ -23,6 +23,7 @@ Users execute transforms in Docker containers using the ``run`` command:
 ::
 
 	dsdt run [-h] [--backend {Local,AWSBatch}] [--force] [--no-push-input]
+	         [--use-aws-session-token AWS_SESSION_TOKEN_DURATION]
              [-it INPUT_TAG] [-ot OUTPUT_TAG]
              input_bundle output_bundle pipe_cls ...
 
@@ -53,6 +54,10 @@ be defined as `class PipeClass` in the file `module/submodule.py` under
 remote. The user should ensure that the remote copy of the bundle contains
 the correct version of the input to use.
 
+``--use-aws-session-token AWS_SESSION_TOKEN_DURATION`` creates and uses
+temporary AWS credentials within a container running on AWS Batch to obtain
+read/write access to S3 from within the container.
+
 To push and pull bundles to and from a remote, the user needs to have
 appropriate AWS credentials to access the S3 bucket holding the remote. We
 assume that the user has first followed the instructions in the AWS
@@ -82,7 +87,9 @@ file in the ``[run]`` stanza:
 	write access to the S3 bucket holding the remote. The easiest way to
 	accomplish this is the ensure that the AWS IAM role that owns the EC2
 	instances (the "Compute resources: Instance role", which by default is
-	``ecsInstanceRole``) has S3 read/write access.
+	``ecsInstanceRole``) has S3 read/write access. Alternatively, the user
+	can use the ``--use-aws-session-token`` to create and use temporary
+	AWS credentials within the container to obtain read/write access to S3.
 
 Once the user has configured Batch, they can queue jobs using the
 ``--backend AWSBatch`` option to the ``run`` command:

--- a/infrastructure/dockerizer/context.template/Dockerfiles/00-disdat-python-2.7.14-slim.dockerfile
+++ b/infrastructure/dockerizer/context.template/Dockerfiles/00-disdat-python-2.7.14-slim.dockerfile
@@ -1,0 +1,28 @@
+#
+# Kickstart the Python 2 system environment
+#
+
+FROM python:2.7.14-slim
+
+LABEL \
+	author="Theodore Wong"
+
+# Kickstart shell scripts root
+ARG KICKSTART_ROOT
+ENV KICKSTART_ROOT $KICKSTART_ROOT
+
+RUN apt-get update
+RUN apt-get upgrade -y
+
+# Install git and a minimal Python 2.x toolchain. Disdat uses git to detect
+# changed sources when deciding whether or not to rerun a pipeline.
+RUN apt-get install -y git
+RUN easy_install virtualenv
+
+# Install the kickstart scripts used by later layers
+COPY kickstart $KICKSTART_ROOT
+
+# Declare Miniconda configurable arguments. We only need to save the Python
+# virtual environment path for later stages.
+ARG VIRTUAL_ENV
+ENV VIRTUAL_ENV $VIRTUAL_ENV

--- a/infrastructure/dockerizer/context.template/kickstart/bin/kickstart-python.sh
+++ b/infrastructure/dockerizer/context.template/kickstart/bin/kickstart-python.sh
@@ -199,7 +199,7 @@ else
 		exit 1
 	fi
 
-	VIRTUALENV_VERSION=15.0.1
+	VIRTUALENV_VERSION=15.1.0
 	if [ $(virtualenv --version) != $VIRTUALENV_VERSION ]; then
 		warning "Expected virtualenv $VIRTUALENV_VERSION, got $(virtualenv --version)"
 	fi


### PR DESCRIPTION
This pull request adds a `--use-aws-session-token` option to `run` to create and use temporary AWS credentials inside a container running on AWS Batch to enable read/write access to an S3 remote. This gets around access problems if the IAM role that owns the Batch EC2 instances does not have access to S3.

The PR also adds support for using `python:2.7.14-slim` as the base "operating system", which shrinks the Docker images some.