### PR TITLE
Clean up re-run logic

### DIFF
--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -314,7 +314,7 @@ def resolve_bundle(pfs, pipe, is_left_edge_task):
         pfs.new_output_hframe(pipe, is_left_edge_task)
 
     # 4.) Check the inputs -- assumes we have processed upstream tasks already
-    for i, task in enumerate(pipe.requires()):
+    for task in pipe.requires():
         """ Are we re-running an upstream input (look in path cache)?
         At this time the only bundles a task depends on are the ones created by its upstream tasks.
         We have to look through its *current* list of possible upstream tasks, not the ones it had

--- a/disdat/hyperframe.py
+++ b/disdat/hyperframe.py
@@ -1877,7 +1877,7 @@ class FrameRecord(PBObject):
             (FrameRecord)
         """
 
-        print ("File paths are {}".format(file_paths))
+        #print ("File paths are {}".format(file_paths))
 
         if isinstance(file_paths[0], luigi.LocalTarget):
             file_paths = ['file://{}'.format(lt.path) if lt.path.startswith('/') else lt.path for lt in file_paths]

--- a/disdat/hyperframe.py
+++ b/disdat/hyperframe.py
@@ -1877,8 +1877,6 @@ class FrameRecord(PBObject):
             (FrameRecord)
         """
 
-        #print ("File paths are {}".format(file_paths))
-
         if isinstance(file_paths[0], luigi.LocalTarget):
             file_paths = ['file://{}'.format(lt.path) if lt.path.startswith('/') else lt.path for lt in file_paths]
 


### PR DESCRIPTION
1.) Removed dead code
2.) Use lineage to detect when upstream data has been modified