### PR TITLE
Support custom Python package indices

### DIFF
--- a/disdat/config/disdat/disdat.cfg
+++ b/disdat/config/disdat/disdat.cfg
@@ -22,6 +22,7 @@ ignore_code_version=False
 [dockerize]
 os_type = python
 os_version = 2.7.14-slim
+#dot_pip_file = ~/.pip/pip.conf
 
 [run]
 # For AWS Batch: A job queue

--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/01-disdat-python.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/01-disdat-python.dockerfile
@@ -29,3 +29,7 @@ ENV PATH $VIRTUAL_ENV/bin:$PATH
 
 # Initialize the Disdat environment
 RUN dsdt init
+
+# Local environment may have its own pip index, support pip.conf files
+COPY pip.conf /opt/pip.conf
+ENV PIP_CONFIG_FILE /opt/pip.conf


### PR DESCRIPTION
Added configuration option in disdat.cfg to point to a 'pip.conf' file. 
If it exists, copy in to Docker context, else, create empty file.   Dockerfile now sets PIP_CONFIG_FILE environment variable to point to file. 