### PR TITLE
Specify additional bundles to download when running Dockerized pipelines  

### DIFF
--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -243,10 +243,11 @@ def different_code_versions(code_version, lineage_obj):
 
     conf = common.DisdatConfig.instance()
 
+    if conf.ignore_code_version:
+        return False
+
     # If there were uncommitted changes, then we have to re-run, mark as different
     if code_version.dirty:
-        if conf.ignore_code_version:
-            return False
         return True
 
     if code_version.semver != lineage_obj.pb.code_semver:
@@ -289,7 +290,7 @@ def resolve_bundle(pfs, pipe, is_left_edge_task):
     if bndl is None:
         if verbose: print "resolve_bundle: No bundle with proc_name {}, getting new output bundle.\n".format(pipe.pipe_id())
         # no bundle, force recompute
-        # pfs.new_output_hframe(pipe, is_left_edge_task)
+        pfs.new_output_hframe(pipe, is_left_edge_task)
         return
 
     # 2.) Bundle exists - lineage object tells us input bundles.

--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -289,7 +289,7 @@ def resolve_bundle(pfs, pipe, is_left_edge_task):
     if bndl is None:
         if verbose: print "resolve_bundle: No bundle with proc_name {}, getting new output bundle.\n".format(pipe.pipe_id())
         # no bundle, force recompute
-        pfs.new_output_hframe(pipe, is_left_edge_task)
+        # pfs.new_output_hframe(pipe, is_left_edge_task)
         return
 
     # 2.) Bundle exists - lineage object tells us input bundles.

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -273,6 +273,7 @@ def make_run_command(
         local_ctxt,
         input_tags,
         output_tags,
+        fetch_list,
         pipeline_params,
 ):
     args = [
@@ -286,6 +287,10 @@ def make_run_command(
     if len(output_tags) > 0:
         for next_tag in output_tags:
             args += ['--output-tag', next_tag]
+    if len(fetch_list) > 0:
+        for next_bundle in fetch_list:
+            args += ['--fetch', next_bundle]
+
     args += [input_bundle, output_bundle]
     return [x.strip() for x in args + pipeline_params]
 

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -272,11 +272,6 @@ def main(input_args):
         required=True,
         help='The fully-qualified Disdat branch to use when running',
     )
-    #pipeline_parser.add_argument(
-    #    '--input-tags',
-    #    type=str,
-    #    help='A JSON-encoded dictionary of tags to choose input bundle',
-    #)
 
     pipeline_parser.add_argument(
         '-it', '--input-tag',
@@ -288,11 +283,11 @@ def main(input_args):
         nargs=1, type=str, action='append',
         help="Output bundle tags: '-ot authoritative:True -ot version:0.7.1'")
 
-    #pipeline_parser.add_argument(
-    #    '--output-tags',
-    #    type=str,
-    #    help='A JSON-encoded dictionary of tags to attach to the output bundle',
-    #)
+    pipeline_parser.add_argument(
+        '-f', '--fetch',
+        nargs=1, type=str, action='append',
+        help="Fetch a bundle before execution: '-f some.input.bundle'")
+
     pipeline_parser.add_argument(
         '--output-bundle-uuid',
         default=None,
@@ -358,6 +353,9 @@ def main(input_args):
     output_tags = {}
     if args.output_tag is not None:
         output_tags = disdat.common.parse_args_tags(args.output_tag)
+    fetch_list = []
+    if args.fetch is not None:
+        fetch_list =  ['{}'.format(kv[0]) for kv in args.fetch]
 
     if False:
         print "Container Running with command (output uuid {}, input_tags {}, output_tags {}):".format(args.output_bundle_uuid,
@@ -365,6 +363,11 @@ def main(input_args):
         print "\t dsdt apply {} {} {} {} ".format(args.input_bundle, args.output_bundle, args.pipeline, args.pipeline_args)
 
     # Let it rip!
+    if len(fetch_list) > 0 and (args.remote is not None):
+        _remote(fs, args.remote)
+        for b in fetch_list:
+            _pull(fs, bundle_name=b)
+
     if (
         ((args.no_pull and args.no_push) or (args.remote is None) or _remote(fs, args.remote)) and
         (args.no_pull or (args.input_json is not None) or _pull(fs, bundle_name=args.input_bundle)) and


### PR DESCRIPTION
Added '-f', '--fetch' options to `dsdt run`.   Modified entrypoint so that it fetches the bundles before execution.      