### PR TITLE
Fix option to ignore changes in code version

### DIFF
--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -243,10 +243,11 @@ def different_code_versions(code_version, lineage_obj):
 
     conf = common.DisdatConfig.instance()
 
+    if conf.ignore_code_version:
+        return False
+
     # If there were uncommitted changes, then we have to re-run, mark as different
     if code_version.dirty:
-        if conf.ignore_code_version:
-            return False
         return True
 
     if code_version.semver != lineage_obj.pb.code_semver:

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -554,7 +554,7 @@ class DisdatFS(object):
             committed = 'False'
 
         output_string = "{:20}\t{:20}\t{:8}\t{:18}\t{:8}\t{:40}".format(hfr.pb.human_name,
-                                                                   hfr.pb.processing_name[:20],
+                                                                   hfr.pb.processing_name[:],
                                                                    hfr.pb.owner,
                                                                    time.strftime("%m-%d-%y %H:%M:%S ",time.gmtime(hfr.pb.lineage.creation_date)),
                                                                    committed,

--- a/tests/requires_test.py
+++ b/tests/requires_test.py
@@ -1,0 +1,42 @@
+#
+# Copyright 2017 Human Longevity, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from disdat.pipe import PipeTask
+
+""" Purpose of this test is to show that if you return nothing, you 
+still need to get the input in the downstream task.  See git issue 
+ https://github.com/kyocum/disdat/issues/31
+ """
+
+
+class Bizarre(PipeTask):
+
+    def pipe_requires(self, pipeline_input=None):
+        return
+
+    def pipe_run(self, pipeline_input=None, **kwargs):
+        return
+
+
+class a(Bizarre):
+    def pipe_requires(self, pipeline_input=None):
+        return
+
+
+class b(Bizarre):
+    def pipe_requires(self, pipeline_input=None):
+        self.add_dependency('something',a,{})
+


### PR DESCRIPTION
If one sets the option to ignore code version changes, we now properly ignore any change to code version and always say False. 