### PR TITLE
Improved args for run and cat now takes uuid

### DIFF
--- a/build-exe.sh
+++ b/build-exe.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+echo "Building Disdat executable dsdt . . ."
+
+
+if [ -z ${VIRTUAL_ENV+x} ]; then
+    echo "No current virtual environment";
+else
+    echo "Deactivating current venv $VIRTUAL_ENV";
+    oldpath=$PATH
+    export PATH=`echo $PATH | cut -d : -f 2-`
+    oldve=$VIRTUAL_ENV
+    unset VIRTUAL_ENV
+    oldps1=$PS1
+    unset PS1
+fi
+
+# Assume they have virtualenvwrapper installed in root environment
+
+source `which virtualenvwrapper.sh`
+
+oldwoh=$WORKON_HOME
+
+export WORKON_HOME=~/.virtual_envs
+
+mkvirtualenv disdat-dist
+
+pip install -e .
+
+pip install pyinstaller
+
+# remove all the .pyc files so we don't copy them into the binary folder
+rm `find . -name '*.pyc'`
+
+#pyinstaller --clean --onefile --name dsdt disdat/dsdt.py
+#pyinstaller  --onedir --name dsdt dsdt-onedir.spec
+pyinstaller  --onefile --name dsdt dsdt-onefile.spec
+
+
+if false; then
+    # At one point, pyinstaller was failing.   No longer apears to be the case, but holding on to vistigial code.
+    boto_file=${WORKON_HOME}/disdat-dist/lib/python2.7/site-packages/PyInstaller/hooks/hook-botocore.py
+    sed -i -e 's/from PyInstaller.utils.hooks import collect_data_files/from PyInstaller.utils.hooks import collect_data_files, is_module_satisfies/' $boto_file
+    sed -i -e 's/from PyInstaller.compat import is_py2, is_module_satisfies/from PyInstaller.compat import is_py2/' $boto_file
+    pyinstaller --onefile  --name dsdt dsdt-mod.spec
+fi
+
+
+# Manual re-activate
+if [ -z ${oldve+x} ]; then
+    unset VIRTUAL_ENV
+else
+    export PATH=$oldpath
+    export VIRTUAL_ENV=$oldve
+    export PS1=$oldps1
+fi
+
+rmvirtualenv disdat-dist
+
+export WORKON_HOME=$oldwoh
+
+echo "Finished"
+

--- a/disdat/api.py
+++ b/disdat/api.py
@@ -554,7 +554,7 @@ def push(local_context, bundle_name, tags=None, uuid=None):
 
     Args:
         local_context (str): <remote context>/<local context> or <local context>
-        bundle_name (str): human name of the bundle to push
+        bundle_name (str): human name of the bundle to push or None (if using uuid)
         tags (dict): Tags that bundle should have
         uuid (str): Optional UUID of the bundle to push.  If specified with bundle_name, UUID takes precedence.
 

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -278,15 +278,23 @@ def make_run_command(
         output_tags,
         fetch_list,
         no_pull,
+        no_push,
+        no_push_int,
+        workers,
         pipeline_params
 ):
     args = [
         '--output-bundle-uuid ', output_bundle_uuid,
         '--remote', remote,
         '--branch', local_ctxt,
+        '--workers', unicode(workers)
     ]
     if no_pull:
         args += ['--no-pull']
+    if no_push:
+        args += ['--no-push']
+    if no_push_int:
+        args += ['--no-push-intermediates']
     if len(input_tags) > 0:
         for next_tag in input_tags:
             args += ['--input-tag', next_tag]

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1598,7 +1598,7 @@ def _ls(fs, args):
 
 def _cat(fs, args):
 
-    df = fs.cat(args.bundle, tags=common.parse_args_tags(args.tag), file=args.file)
+    df = fs.cat(args.bundle, uuid=args.uuid, tags=common.parse_args_tags(args.tag), file=args.file)
 
     if df is None:
         print "dsdt cat found no bundle with name {}".format(args.bundle)
@@ -1690,11 +1690,12 @@ def init_fs_cl(subparsers):
 
     # cat
     cat_p = subparsers.add_parser('cat')
-    cat_p.add_argument('bundle', type=str, help='A bundle in the current context')
+    cat_p.add_argument('bundle', type=str, nargs='?', default=None, help='The bundle name in the current context')
     cat_p.add_argument('-t', '--tag', nargs=1, type=str, action='append',
                       help="Having a specific tag: 'dsdt ls -t committed:True -t version:0.7.1'")
     cat_p.add_argument('-f', '--file', type=str,
                        help="Save output dataframe as csv without index to specified file")
+    cat_p.add_argument('-u', '--uuid', type=str, default=None, help='Bundle UUID to cat')
     cat_p.set_defaults(func=lambda args: _cat(fs, args))
 
     # status

--- a/disdat/infrastructure/dockerizer/context.template/bin/sagemaker.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/sagemaker.py
@@ -50,7 +50,7 @@ def train():
 
 
 if __name__ == '__main__':
-    """ SageMaker invoke sthe container with 'train' or 'serve'.
+    """ SageMaker invokes the container with 'train' or 'serve'.
     Train jobs support arbitrary 'hyperparameter' params inside a json blob.
     We read the json and interpret them as arguments to the Disdat entrypoint.
 


### PR DESCRIPTION
1.) run args
   removed args to avoid pushing input bundle
   added --no-push to keep from pushing any generated data to remote context
   added --no-push-intermediates to not push intermediates (if --no-push is not used)
   added -w option to specify luigi workers, and made 2 the default
2.) Fixed run bug, where it wouldn't push output bundle if you used `- -`
3.) Added cat by uuid
4.) Changed --backend AWSBatch, so that the session token is always defined at 1440 seconds. 
