### PR TITLE
 Apply returns num run tasks and updated entrypoint

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -334,7 +334,7 @@ def _get_context(context_name):
 
 
 def current_context():
-    """ Return the current context """
+    """ Return the current context name (not object) """
 
     try:
         return fs.get_curr_context().get_local_name()
@@ -520,7 +520,6 @@ def rm(local_context, bundle_name, uuid=None):
     Returns:
 
     """
-
 
 
 def cat(local_context, bundle_name):

--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -216,7 +216,7 @@ def resolve_workflow_bundles(root_task, data_context):
         data_context:
 
     Returns:
-        bool: True if there is anything to re-run, False if no work to be done (only driver wrapper task)
+        bool: is_work -- True if there is anything to re-run, False if no work to be done (only driver wrapper task)
 
     """
 
@@ -240,7 +240,7 @@ def resolve_workflow_bundles(root_task, data_context):
             num_regen += 1
 
     # If regen == 0, then there is nothing to run.
-    return num_regen == 0
+    return num_regen > 0
 
 
 def different_code_versions(code_version, lineage_obj):
@@ -295,7 +295,7 @@ def resolve_bundle(pfs, pipe, is_left_edge_task, data_context):
 
     verbose = False
     use_bundle = True
-    regen_bundle = True
+    regen_bundle = False
 
     # 1.) Get output bundle for pipe_id (the specific pipeline/transform/param hash).
 


### PR DESCRIPTION
Entrypoint updated so we switch into the context so that running tasks can use the api internally by finding the current context. 

Only switch into the given local context IFF we are NOT in a context currently. 
Thus we are not changing the state of the local drive if we are running this container locally. 
This needs a bit more work, but this allows running tasks to find the current context.  Otherwise 
it has to be parameterized into the pipeline.   