### PR TITLE
Better handling of Luigi task failures 

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -54,7 +54,7 @@ import json
 import disdat.apply
 import disdat.run
 import disdat.fs
-import disdat.common
+import disdat.common as common
 from disdat.pipe_base import PipeBase
 from disdat.db_target import DBTarget
 
@@ -637,15 +637,27 @@ def apply(local_context, input_bundle, output_bundle, transform,
     if params is None:
         params = {}
 
+    result = {'success': False, 'did_work': False}
+
     try:
         dynamic_params = json.dumps(params)
-        disdat.apply.apply(input_bundle, output_bundle, dynamic_params, transform,
-                           input_tags, output_tags, force, output_bundle_uuid=output_bundle_uuid,
-                           sysexit=False, central_scheduler=central_scheduler,
-                           workers=workers, data_context=data_context)
+
+        result = disdat.apply.apply(input_bundle, output_bundle, dynamic_params, transform,
+                                    input_tags, output_tags, force,
+                                    output_bundle_uuid=output_bundle_uuid,
+                                    central_scheduler=central_scheduler,
+                                    workers=workers,
+                                    data_context=data_context)
 
     except SystemExit as se:
-        print "SystemExit caught: {}".format(se)
+        print "Disdat api.apply caught SystemExist exception: {}".format(se)
+
+    except Exception as e:
+        print "Disdat api.apply caught Exception exception: {}".format(e)
+
+    finally:
+        common.apply_handle_result(result, raise_not_exit=True)
+
 
 
 def run(local_context, input_bundle, output_bundle, transform, input_tags, output_tags, force=False, **kwargs):

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -49,9 +49,36 @@ BUNDLE_URI_SCHEME = 'bundle://'
 PUT_LUIGI_PARAMS_IN_FUNC_PARAMS = False  # transparently place luigi parameters as kwargs in run() and requires()
 
 
+class ApplyException(Exception):
+    pass
+
+
 def error(msg, *args, **kwargs):
     _logger.error(msg, *args, **kwargs)
     sys.exit(1)
+
+
+def apply_handle_result(apply_result, raise_not_exit=False):
+    """ Execute an appropriate sys.exit() call based on the dictionary
+    returned by apply.
+
+    Args:
+        apply_result(dict): Has keys 'success' and 'did_work' that give Boolean values.
+        raise_not_exit (bool): Raise ApplyException instead of performing sys.exit
+
+    Returns:
+        None
+
+    """
+
+    if apply_result['success']:
+        sys.exit(None) # None yields exit value of 0
+    else:
+        error_str = "Disdat Apply ran, but one or more tasks failed."
+        if raise_not_exit:
+            raise ApplyException(error_str)
+        else:
+            sys.exit(error_str)
 
 
 def setup_default_logging():

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -301,6 +301,10 @@ def run_disdat_container(args):
         _logger.error('Failed to run pipeline: exception {}'.format(re))
         sys.exit(os.EX_IOERR)
 
+    except disdat.common.ApplyException as ae:
+        _logger.error('ApplyException running pipeline: exception {}'.format(re))
+        sys.exit(os.EX_IOERR)
+
     if args.dump_output:
         print(disdat.api.cat(args.branch, args.output_bundle))
     sys.exit(os.EX_OK)

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -461,7 +461,7 @@ def add_arg_parser(parsers):
     run_p.add_argument(
         '--use-aws-session-token',
         nargs=1,
-        default=[1440],
+        default=[43200], # 12 hours of default time -- for long pipelines!
         type=int,
         help='Use temporary AWS session token for AWS Batch, valid for AWS_SESSION_TOKEN_DURATION seconds. Default 1440. Set to zero to not use a token.',
         dest='aws_session_token_duration',


### PR DESCRIPTION
1.) Added ApplyException.
2.) Apply returns result that indicates run success
3.) CLI apply will sys.exit(>0) if failure
4.) api.apply will raise ApplyException 
5.) Entrypoint will catch ApplyException and sys.exit(>0)
6.) Cleaned up apply.apply so it no longer calls luigi.run_with_retcodes()
7.) Default 'dsdt.run' on AWS Batch token expiration set to 12 hours. 