### PR TITLE
Entrypoint Fixes

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -656,6 +656,8 @@ def apply(local_context, input_bundle, output_bundle, transform,
     # For CLI, we exit with 1
     common.apply_handle_result(result, raise_not_exit=True)
 
+    return result
+
 
 def run(local_context, input_bundle, output_bundle, transform, input_tags, output_tags, force=False, **kwargs):
     """

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -72,7 +72,10 @@ def apply_handle_result(apply_result, raise_not_exit=False):
     """
 
     if apply_result['success']:
-        sys.exit(None) # None yields exit value of 0
+        if raise_not_exit:
+            pass
+        else:
+            sys.exit(None) # None yields exit value of 0
     else:
         error_str = "Disdat Apply ran, but one or more tasks failed."
         if raise_not_exit:

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -127,13 +127,10 @@ def _run_local(arglist, pipeline_class_name, backend):
                 _logger.info("VOLUMES: {}".format(volumes))
         else:
             pipeline_image_name = common.make_pipeline_image_name(pipeline_class_name)
-            args = ' '.join(arglist)
 
-        _logger.debug('Running image {} with arguments {}'.format(pipeline_image_name, args))
+        _logger.debug('Running image {} with arguments {}'.format(pipeline_image_name, arglist))
 
-        print('Running image {} with arguments {}'.format(pipeline_image_name, args))
-
-        stdout = client.containers.run(pipeline_image_name, args, detach=False,
+        stdout = client.containers.run(pipeline_image_name, arglist, detach=False,
                                        environment=environment, init=True, stderr=True, volumes=volumes)
         print stdout
     except docker.errors.ImageNotFound:
@@ -422,6 +419,7 @@ def _run(
             _run_aws_sagemaker(arglist, job_name, pipeline_class_name)
 
     elif backend == Backend.Local or backend == Backend.LocalSageMaker:
+
         _run_local(arglist, pipeline_class_name, backend)
 
     else:


### PR DESCRIPTION
Output of apply in api.apply() was ignoring raise_not_exit.
Local container runs now interpret json arg strings correctly.
Added logging statements to entrypoint.  