### PR TITLE
Kyocum/lazy pull

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -594,8 +594,9 @@ def pull(local_context, bundle_name=None, uuid=None, localize=False):
 
 
 def apply(local_context, input_bundle, output_bundle, transform,
-          input_tags=None, output_tags=None, force=False, params=None, output_bundle_uuid=None,
-          central_scheduler=False, workers=1, incremental_push=False):
+          input_tags=None, output_tags=None, force=False, params=None,
+          output_bundle_uuid=None, central_scheduler=False, workers=1,
+          incremental_push=False, incremental_pull=False):
     """
     Similar to apply.main() but we create our inputs and supply the context
     directly.
@@ -613,6 +614,7 @@ def apply(local_context, input_bundle, output_bundle, transform,
         central_scheduler (bool): Use a central scheduler, default False, i.e., use local scheduler
         workers (int): Number of workers, default 1.
         incremental_push (bool): commit and push task bundles as they complete
+        incremental_pull (bool): localize bundles from remote as they are required by downstream tasks
 
     Returns:
 
@@ -642,7 +644,8 @@ def apply(local_context, input_bundle, output_bundle, transform,
                                 central_scheduler=central_scheduler,
                                 workers=workers,
                                 data_context=data_context,
-                                incremental_push=incremental_push)
+                                incremental_push=incremental_push,
+                                incremental_pull=incremental_pull)
 
     # If no raise, but luigi says not successful
     # If API (here), then raise for caller to catch.

--- a/disdat/api.py
+++ b/disdat/api.py
@@ -108,13 +108,12 @@ class BundleWrapperTask(PipeTask):
     creation_date = luigi.Parameter(default=None)
 
     def bundle_inputs(self):
-        """ Determine input bundles
+        """ Determine input bundles """
+        raise NotImplementedError
 
-        Returns
-          [(processing_name, uuid), ... ]
-
-        """
-        return []
+    def bundle_outputs(self):
+        """ Determine input bundles """
+        raise NotImplementedError
 
 
 class Bundle(object):
@@ -154,8 +153,9 @@ class Bundle(object):
         self.closed = False
 
         self.input_data = None  # The df, array, dictionary the user wants to store
-        self.tags = {}    # The dictionary of (str):(str) tags the user wants to attach
+        self.tags = {}          # The dictionary of (str):(str) tags the user wants to attach
         self.db_targets = []    # list of created db targets
+        self.depends_on = []    # list of tuples (processing_name, uuid) of bundles on which this bundle depends
         self.data = None
 
         self.uuid = None        # Internal uuid of this bundle.
@@ -182,6 +182,7 @@ class Bundle(object):
         self.creation_date = hfr.pb.lineage.creation_date
         self.uuid = hfr.pb.uuid
         self.presentation = hfr.pb.presentation
+        self.depends_on = hfr.pb.lineage.depends_on
 
         self.data = self.data_context.convert_hfr2df(hfr)
         self.tags = hfr.tag_dict
@@ -231,7 +232,7 @@ class Bundle(object):
             # only sets it in the object
             self._set_processing_name()
 
-            def parse_api_return_val(hfid, val, data_context, bundle_inputs, bundle_name, bundle_processing_name, pipe):
+            #def parse_api_return_val(hfid, val, data_context, bundle_inputs, bundle_name, bundle_processing_name, pipe):
 
             hfr = PipeBase.parse_api_return_val(self.uuid,
                                                 self.data,
@@ -239,6 +240,7 @@ class Bundle(object):
                                                 self.bundle_inputs(),
                                                 self.name,
                                                 self.processing_name,
+                                                BundleWrapperTask
                                                 )
 
             hfr.replace_tags(self.tags)

--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -45,7 +45,7 @@ META_FILE = 'info.json'
 
 def apply(input_bundle, output_bundle, pipe_params, pipe_cls, input_tags, output_tags, force,
           output_bundle_uuid=None, central_scheduler=False, workers=1, data_context=None,
-          incremental_push=False):
+          incremental_push=False, incremental_pull=False):
     """
     Given an input bundle, run the pipesline on the bundle.
     Note, we first make a copy of all tasks that are parameterized identically to the tasks we will run.
@@ -66,6 +66,7 @@ def apply(input_bundle, output_bundle, pipe_params, pipe_cls, input_tags, output
         workers: The number of luigi workers to use for this workflow (default 1)
         data_context: Actual context object or None and read current context.
         incremental_push (bool): Whether this job should push tasks as they complete to the remote (if configured)
+        incremental_pull (bool): Whether this job should localize bundles as needed from the remote (if configured)
 
     Returns:
         bool: True if tasks needed to be run, False if no tasks (beyond wrapper task) executed.
@@ -81,9 +82,13 @@ def apply(input_bundle, output_bundle, pipe_params, pipe_cls, input_tags, output
     _logger.debug("central_scheduler {}".format(central_scheduler))
     _logger.debug("workers {}".format(workers))
     _logger.debug("incremental_push {}".format(incremental_push))
+    _logger.debug("incremental_pull {}".format(incremental_pull))
 
     if incremental_push:
         _logger.warn("incremental_push {}".format(incremental_push))
+
+    if incremental_pull:
+        _logger.warn("incremental_pull {}".format(incremental_push))
 
     pfs = fs.DisdatFS()
 
@@ -97,7 +102,8 @@ def apply(input_bundle, output_bundle, pipe_params, pipe_cls, input_tags, output
     # Creates a cache of {pipe:path_cache_entry} in the pipesFS object.
     # This "task_path_cache" is used throughout execution to find output bundles.
     reexecute_dag = driver.DriverTask(input_bundle, output_bundle, pipe_params,
-                                      pipe_cls, input_tags, output_tags, force, data_context, incremental_push)
+                                      pipe_cls, input_tags, output_tags, force,
+                                      data_context, incremental_push, incremental_pull)
 
     did_work = resolve_workflow_bundles(reexecute_dag, data_context)
 
@@ -416,7 +422,8 @@ def main(args):
                    args.force,
                    central_scheduler=args.central_scheduler,
                    workers=args.workers,
-                   incremental_push=args.incremental_push)
+                   incremental_push=args.incremental_push,
+                   incremental_pull=args.incremental_pull)
 
     # If we didn't successfully run any task, sys.exit with non-zero code
     common.apply_handle_result(result)

--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -28,7 +28,6 @@ import logging
 import sys
 import json
 import collections
-import inspect
 import disdat.common as common  # config, especially logging, before luigi ever loads
 import disdat.pipe_base as pipe_base
 import disdat.fs as fs

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -46,6 +46,9 @@ DISDAT_CONTEXT_DIR = 'context'  # ~/.disdat/context/<local_context_name>
 DEFAULT_FRAME_NAME = 'unnamed'
 BUNDLE_URI_SCHEME = 'bundle://'
 
+# Some tags in bundles are special.  They are prefixed with '__'
+BUNDLE_TAG_PARAMS_PREFIX = '__param_'
+
 
 class ApplyException(Exception):
     pass

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -46,8 +46,6 @@ DISDAT_CONTEXT_DIR = 'context'  # ~/.disdat/context/<local_context_name>
 DEFAULT_FRAME_NAME = 'unnamed'
 BUNDLE_URI_SCHEME = 'bundle://'
 
-PUT_LUIGI_PARAMS_IN_FUNC_PARAMS = False  # transparently place luigi parameters as kwargs in run() and requires()
-
 
 class ApplyException(Exception):
     pass

--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -592,6 +592,7 @@ class DataContext(object):
                 self.rm_db_links(hfr[0], dry_run=False)
                 shutil.rmtree(self.implicit_hframe_path(hfr_uuid))
                 hyperframe.delete_hfr_db(self.local_engine, uuid=hfr_uuid)
+                hyperframe.delete_fr_db(self.local_engine, hfr_uuid)
             else:
                 print ("Disdat: Looks like you're trying to remove a committed bundle with a db link backing a view.")
                 print ("Disdat: Removal of this bundle with db links that back a view requires '--force'")

--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -1123,7 +1123,6 @@ class DataContext(object):
                 _logger.warn("Not copying-in a string-based database reference[{}].  Disdat only supports string refs from DBTarget objects.".format(src_path))
                 file_set.append(src_path)
                 continue
-                #raise Exception("data_context:copy_in_files error trying to copy in string-based database reference.")
 
             # Src path can contain a sub-directory.
             sub_dir = DataContext.find_subdir(src_path, dst_dir)

--- a/disdat/driver.py
+++ b/disdat/driver.py
@@ -75,6 +75,7 @@ class DriverTask(luigi.WrapperTask, PipeBase):
     force = luigi.BoolParameter(default=False)
     data_context = luigi.Parameter(significant=False)
     incremental_push = luigi.BoolParameter(default=False, significant=False)
+    incremental_pull = luigi.BoolParameter(default=False, significant=False)
 
     def __init__(self, *args, **kwargs):
         """
@@ -250,26 +251,6 @@ class DriverTask(luigi.WrapperTask, PipeBase):
 
         for p in param_bundles:
             bundle_name = param_bundles[p]
-            #print "p {}".format(p)
-            #print "bundle_name {}".format(bundle_name)
-
-            #
-            # TODO:  We used to automatically find strings that looked like bundle names
-            # and then automatically convert them to dataframes.  However, we need a more robust
-            # way to identify possible bundle arguments and we should use the Bundle presentation
-            # layer to create the Python object.  So for now we just treat everything as literal values.
-            # 12-17-2017 KGY
-            #
-
-            # if DisdatFS.is_input_param_bundle_name(bundle_name):
-            #     ''' Get dataframe '''
-            #     bundle_df = pfs.cat(bundle_name)
-            #     if bundle_df is None:
-            #         _logger.warn("Bundle {} does not exist".format(bundle_name))
-            #         raise exceptions.BundleError("Bundle {} does not exist".format(bundle_name))
-            #     else:
-            #         resolved[p] = bundle_df
-            # else:
 
             ''' Get a literal '''
             resolved[p] = LiteralParam(bundle_name)
@@ -323,7 +304,8 @@ class DriverTask(luigi.WrapperTask, PipeBase):
                        'force': self.force,
                        'output_tags': json.dumps(dict(self.output_tags)), # Ugly re-stringifying dict
                        'data_context': self.data_context,
-                       'incremental_push': self.incremental_push
+                       'incremental_push': self.incremental_push,
+                       'incremental_pull': self.incremental_pull
                        }
 
         task_params.update(param_dfs_json)

--- a/disdat/dsdt.py
+++ b/disdat/dsdt.py
@@ -103,6 +103,7 @@ def main():
     apply_p.add_argument("--local", action='store_true', help="Run the class locally (even if dockered)")
     apply_p.add_argument("--force", action='store_true', help="If there are dependencies, force re-computation.")
     apply_p.add_argument("--incremental-push", action='store_true', help="Commit and push each task's bundle as it is produced to the remote.")
+    apply_p.add_argument("--incremental-pull", action='store_true', help="Localize bundles as they are needed by downstream tasks from the remote.")
     apply_p.add_argument("params", type=str,  nargs=argparse.REMAINDER,
                          help="Optional set of parameters for this pipe '--parameter value'")
     apply_p.set_defaults(func=lambda args: _apply(args))

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -837,7 +837,7 @@ class DisdatFS(object):
         Database links are special.  Commits materialize special views of the physical table.
 
         Args:
-            bundle_name (str): The name of the bundle to commit
+            bundle_name (str): The name of the bundle to commit.  Ignored if uuid is set.
             input_tags (dict): Commit the bundle that has these tags
             uuid (str): The uuid of the bundle to commit.
             data_context (`disdat.data_context.DataContext`): Optional data context in which to find / commit bundle.
@@ -888,7 +888,6 @@ class DisdatFS(object):
 
         # Commit to disk:
         data_context.atomic_update_hframe(hfr)
-
 
     def _get_all_link_frames(self, outer_hfr, local_fs_frames=False, s3_frames=False, db_frames=False):
         """

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -26,7 +26,7 @@ import disdat.hyperframe as hyperframe
 import disdat.common as common
 import disdat.utility.aws_s3 as aws_s3
 from disdat.data_context import DataContext
-from disdat.common import DisdatConfig, error
+from disdat.common import DisdatConfig
 
 import logging
 import os
@@ -586,7 +586,7 @@ class DisdatFS(object):
 
     def cat(self, human_name, uuid=None, tags=None, file=None, data_context=None):
         """
-        Given a bundle name and optional uuid, return a dataframe with its contents
+        Given a bundle name and optional uuid, return the object that was saved in the bundle
 
         Args:
             human_name (str):
@@ -596,7 +596,7 @@ class DisdatFS(object):
             data_context (`disdat.data_context.DataContext`):
 
         Returns:
-            (`DataFrame`):
+            (`DataFrame`) or (`numpy.ndarray`) or scalar type
         """
 
         if data_context is None:
@@ -611,11 +611,12 @@ class DisdatFS(object):
             hfr = self.get_hframe_by_uuid(uuid, tags=tags, data_context=data_context)
 
         if hfr is not None:
-            df = data_context.convert_hfr2df(hfr)
+            df    = data_context.convert_hfr2df(hfr)
+            other = data_context.present_hfr(hfr)
             if df is not None and file is not None:
                 print "Saving to file {}".format(file)
                 df.to_csv(file, sep=',', index=False)
-            return df
+            return other #df
         else:
             return None
 
@@ -739,13 +740,14 @@ class DisdatFS(object):
                                                                                                       local_context,
                                                                                                       context.get_object_dir()))
 
-    def delete_branch(self, fq_context_name, force):
+    def delete_branch(self, fq_context_name, remote, force):
         """
 
         Delete a branch at <repo>/<context_name> or <context name>
 
         Args:
             fq_context_name:  The unique string for a context
+            remote: whether to also remove the remote on S3
             force: whether to force delete a dirty context
 
         Returns:
@@ -761,14 +763,16 @@ class DisdatFS(object):
 
         if local_context in self._all_contexts:
             dc = self._all_contexts[local_context]
+            remote_context_url= dc.get_remote_object_dir()
             dc.delete_branch(force=force)
             del self._all_contexts[local_context]
-        else:
-            assert(True)
 
         if os.path.exists(ctxt_dir):
             shutil.rmtree(ctxt_dir)
             _logger.info("Disdat deleted local data context {}.".format(local_context))
+            if remote:
+                aws_s3.delete_s3_dir(remote_context_url)
+                _logger.info("Disdat deleted remote data context {}.".format(remote_context_url))
         else:
             _logger.info("Disdat local data context {} appears to already have been deleted.".format(local_context))
 
@@ -1447,7 +1451,7 @@ class DisdatFS(object):
 
                 _logger.info("Adding HyperFrame UUID {} to local context . . .".format(s3_uuid))
 
-                local_uuid_dir = os.path.join(self.get_curr_context().get_object_dir(), s3_uuid)
+                local_uuid_dir = os.path.join(data_context.get_object_dir(), s3_uuid)
                 local_hfr_path = os.path.join(local_uuid_dir, hfr_basename)
                 if os.path.exists(local_uuid_dir):
                     print "Pull found existing data in local disdat db at UUID {}, overwriting . . .".format(s3_uuid)
@@ -1458,7 +1462,7 @@ class DisdatFS(object):
                 hyperframe.w_pb_fs(None, hfr_test, local_hfr_path)
 
                 # grab frames for this hyperframe
-                s3_hfr_dir = os.path.join(self.get_curr_context().get_remote_object_dir(), s3_uuid)
+                s3_hfr_dir = os.path.join(data_context.get_remote_object_dir(), s3_uuid)
                 possible_frame_objects = aws_s3.ls_s3_url_objects(s3_hfr_dir)
                 frame_objects = [obj for obj in possible_frame_objects if '_frame.pb' in obj.key]
                 for s3_fr_obj in frame_objects:
@@ -1466,7 +1470,7 @@ class DisdatFS(object):
                     local_fr_path = os.path.join(local_uuid_dir,fr_basename)
                     s3_fr_obj.Object().download_file(local_fr_path)
 
-                self.get_curr_context().write_hframe_db_only(hfr_test)
+                data_context.write_hframe_db_only(hfr_test)
 
                 if localize:
                     DisdatFS._localize_hfr(self.get_hframe_by_uuid(s3_uuid, data_context=data_context),
@@ -1524,7 +1528,7 @@ class DisdatFS(object):
 
 def _branch(fs, args):
     if args.delete:
-        fs.delete_branch(args.context, args.force)
+        fs.delete_branch(args.context, args.remote, args.force)
     else:
         fs.branch(args.context)
 
@@ -1597,15 +1601,19 @@ def _ls(fs, args):
 
 def _cat(fs, args):
 
-    df = fs.cat(args.bundle, uuid=args.uuid, tags=common.parse_args_tags(args.tag), file=args.file)
+    result = fs.cat(args.bundle, uuid=args.uuid, tags=common.parse_args_tags(args.tag), file=args.file)
 
-    if df is None:
+    if result is None:
         print "dsdt cat found no bundle with name {}".format(args.bundle)
     else:
-        # make sure we print out all columns
-        pd.set_option('display.max_colwidth', -1)
-        print df.to_string()
 
+        if isinstance(result, pd.DataFrame):
+            # If df, make sure we print out all columns
+            pd.set_option('display.max_colwidth', -1)
+            print result.to_string()
+        else:
+            # else default print the object
+            print result
 
 def _status(fs, args):
     for f in fs.status(args.bundle):
@@ -1624,6 +1632,7 @@ def init_fs_cl(subparsers):
     context_p = subparsers.add_parser('context')
     context_p.add_argument('-f', '--force', action='store_true', help='Force remove of a dirty local context')
     context_p.add_argument('-d','--delete', action='store_true', help='Delete local context')
+    context_p.add_argument('-r','--remote', action='store_true', help='Delete remote context along with local context')
     context_p.add_argument(
         'context',
         nargs='?',

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1292,9 +1292,7 @@ class DisdatFS(object):
     @staticmethod
     def _localize_hfr(local_hfr, s3_uuid, data_context):
         """
-        Given local hfr, read link frames and pulgl data from s3.
-
-        TODO: Checks to see if the files are already local!
+        Given local hfr, read link frames and pull data from s3.
 
         Args:
             local_hfr:
@@ -1309,7 +1307,6 @@ class DisdatFS(object):
             if fr.is_link_frame():
                 src_paths = data_context.actualize_link_urls(fr)
                 for f in src_paths:
-                    print "Adding file {} to bundle".format(f)
                     DataContext.copy_in_files(f, managed_path)
 
     @staticmethod

--- a/disdat/hyperframe.py
+++ b/disdat/hyperframe.py
@@ -1300,26 +1300,6 @@ class LineageRecord(PBObject):
         """
         return "{}_lineage.pb".format(self.pb.uuid)
 
-    def make_lineage_record(hframe_name, hfid, depends_on=None):
-        """
-
-        Args:
-            hframe_name:
-            hfid:
-            depends_on:
-
-        Returns:
-            (`LineageRecord`)
-
-        """
-
-        lr = LineageRecord(hframe_name=hframe_name, hframe_uuid=hfid,
-                           code_repo='bigdipper', code_name='unknown',
-                           code_semver='0.1.0', code_hash='5cd60d3',
-                           code_branch='develop', depends_on=depends_on)
-
-        return lr
-
 
 class FrameRecord(PBObject):
 

--- a/disdat/hyperframe.py
+++ b/disdat/hyperframe.py
@@ -448,6 +448,31 @@ def delete_hfr_db(engine_g, uuid=None, owner=None, human_name=None, processing_n
     return results
 
 
+def delete_fr_db(engine_g, hfr_uuid):
+    """ Remove all frames from the database that belong to the hyperframe with uuid hfr_uuid
+
+    Args:
+        engine_g: query engine
+        hfr_uuid: the hyperframe uuid to which the frames belong
+
+    Returns:
+        results
+    """
+
+    pb_cls = FrameRecord
+
+    where = "WHERE hframe_uuid {}".format(_translate(hfr_uuid))
+
+    fr_del = text(
+        "DELETE FROM {} {}".format(pb_cls.table_name, where)
+    )
+
+    with engine_g.connect() as conn:
+        results = conn.execute(fr_del)
+
+    return [results]
+
+
 def get_files_in_dir(dir):
     """ Look for files in a user returned directory
     1.) Only look one-level down (in this directory)

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -277,12 +277,16 @@ def run_disdat_container(args):
     # convert string of pipeline args into dictionary for api.apply
     pipeline_args = disdat.common.parse_params(args.pipeline_args)
 
-    try:
+    # If the user wants final and intermediate, then inc push.
+    if not args.no_push and not args.no_push_intermediates:
+        incremental_push = True
+    else:
+        incremental_push = False
 
-        if not args.no_push and not args.no_push_intermediates:
-            incremental_push = True
-        else:
-            incremental_push = False
+    # By default containerized execution ALWAYS localize's bundles on demand
+    incremental_pull = True
+
+    try:
 
         result = disdat.api.apply(args.branch,
                                   args.input_bundle,
@@ -294,7 +298,8 @@ def run_disdat_container(args):
                                   output_bundle_uuid=args.output_bundle_uuid,
                                   force=args.force,
                                   workers=args.workers,
-                                  incremental_push=incremental_push)
+                                  incremental_push=incremental_push,
+                                  incremental_pull=incremental_pull)
 
         if not incremental_push:
             if not args.no_push:

--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -79,7 +79,7 @@ class PipeTask(luigi.Task, PipeBase):
     output_tags = luigi.DictParameter(default={}, significant=True)
 
     # Each pipeline executes wrt a data context.
-    data_context = luigi.Parameter(significant=False)
+    data_context = luigi.Parameter(default=None, significant=False)
 
     # Each pipeline can be configured to commit and push intermediate values to the remote
     incremental_push = luigi.BoolParameter(default=False, significant=False)

--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -34,12 +34,10 @@ author: Kenneth Yocum
 
 from disdat.pipe_base import PipeBase
 from disdat.db_target import DBTarget
-import disdat.common as common
 from disdat.driver import DriverTask
-import shutil
+from disdat.fs import DisdatFS
 import luigi
 import logging
-import json
 import os
 
 
@@ -86,6 +84,9 @@ class PipeTask(luigi.Task, PipeBase):
     # Each pipeline can be configured to commit and push intermediate values to the remote
     incremental_push = luigi.BoolParameter(default=False, significant=False)
 
+    # Each pipeline can be configured to pull intermediate values on demand from the remote
+    incremental_pull = luigi.BoolParameter(default=False, significant=False)
+
     def __init__(self, *args, **kwargs):
         """
         This has the same signature as luigi.Task.
@@ -97,20 +98,6 @@ class PipeTask(luigi.Task, PipeBase):
         """
 
         super(PipeTask, self).__init__(*args, **kwargs)
-
-        if common.PUT_LUIGI_PARAMS_IN_FUNC_PARAMS:
-            # NOTE: Default is not to do this.
-            # Set up param values to be used in prepare_pipe_kwargs
-            # Determine all params -- these are lists of tuples [('name', param value),]
-            # Note: using get_param_values, not get_params, which returns parameter objects.
-            only_pipe_params = PipeTask.get_params()
-            all_params = self.get_params()
-            only_subcls_params = tuple(set(all_params) - set(only_pipe_params))
-
-            # This is pretty gross.  Get the params that are unique to this pipe
-            # Pull them out of kwargs (that's how we build this task! we don't use args!)
-            filtered_kwargs = {k: kwargs[k] for k, v in only_subcls_params if k in kwargs}  # @UnusedVariable
-            self.only_subcls_param_values = self.get_param_values(only_subcls_params, [], filtered_kwargs)
 
         # Get the presentable input params from the closure_hframe
         if self.closure_hframe is not None:
@@ -270,7 +257,8 @@ class PipeTask(luigi.Task, PipeBase):
                 'force': self.force,
                 'output_tags': dict({}),  # do not pass output_tags up beyond root task
                 'data_context': self.data_context,  # all operations wrt this context
-                'incremental_push': self.incremental_push  # propagate the choice to push incremental data.
+                'incremental_push': self.incremental_push,  # propagate the choice to push incremental data.
+                'incremental_pull': self.incremental_pull  # propagate the choice to incrementally pull data.
             })
             tasks.append(pipe_class(**params))
 
@@ -328,7 +316,13 @@ class PipeTask(luigi.Task, PipeBase):
 
             self.data_context.write_hframe(hfr)
 
-            if self.incremental_push:
+            transient = hfr.get_tag('transient_bundle')
+            if transient is not None and transient == "True":
+                transient = True
+            else:
+                transient = False
+
+            if self.incremental_push and not transient:
                 self.pfs.commit(None, None, uuid=pce.uuid, data_context=self.data_context)
                 self.pfs.push(uuid=pce.uuid, data_context=self.data_context)
 
@@ -340,12 +334,8 @@ class PipeTask(luigi.Task, PipeBase):
         return hfr
 
     def prepare_pipe_kwargs(self, for_run=False):
-        """
-        Convert the Luigi Parameters that are buried in "self" to a set of
-        named arguments that are passed through the function call.
-
-        The first parameter is the set of presentables from the input hyperframe.  It is keyed under
-        CLOSURE_PIPE_INPUT.
+        """ Each upstream task produces a bundle.  Prepare that bundle as input
+        to the user's pipe_run function.
 
         Args:
             for_run (bool): prepare args for run -- at that point all upstream tasks have completed.
@@ -360,32 +350,27 @@ class PipeTask(luigi.Task, PipeBase):
         # 1.) Place input hyperframe presentable into the users's run / requires function
         kwargs[CLOSURE_PIPE_INPUT] = self.presentable_inputs
 
-        if common.PUT_LUIGI_PARAMS_IN_FUNC_PARAMS:
-            # 2.) Transparently place user's Luigi Params (Task object variables)
-            # This is a list of tuples of name, parameter object.  If from command line, it is json,
-            # if it is the users default value it should throw an exception.
-            for user_pipe_param_name, user_pipe_param in self.only_subcls_param_values:
-                if user_pipe_param is not None:
-                    try:
-                        deserialized = json.loads(user_pipe_param)
-                    except ValueError:
-                        deserialized = user_pipe_param
-                    except TypeError:
-                        deserialized = user_pipe_param
-                    # NOTE: old code made DF if deserialized was a dict: pd.DataFrame.from_dict(deserialized)
-                    kwargs[user_pipe_param_name] = deserialized
-
         # Place upstream task outputs into the kwargs.  Thus the user does not call
         # self.inputs().  If they did, they would get a list of output targets for the bundle
-        # this isn't very helpful.
+        # that isn't very helpful.
         if for_run:
             upstream_tasks = [(t.user_arg_name, self.pfs.get_path_cache(t)) for t in self.requires()]
             for user_arg_name, pce in [u for u in upstream_tasks if u[1] is not None]:
                 hfr = self.pfs.get_hframe_by_uuid(pce.uuid, data_context=self.data_context)
                 assert hfr.is_presentable()
+
+                # Download any data that is not local (the linked files are not present).
+                # This is the default behavior when running in a container.
+                # The non-default is to download and localize ALL bundles in the context before we run.
+                # That's in-efficient.   We only need meta-data to determine what to re-run.
+                if self.incremental_pull:
+                    DisdatFS()._localize_hfr(hfr, pce.uuid, self.data_context)
+
                 if pce.instance.user_arg_name in kwargs:
                     _logger.warning('Task human name {} reused when naming task dependencies: Dependency hyperframe shadowed'.format(pce.instance.user_arg_name))
+
                 kwargs[user_arg_name] = self.data_context.present_hfr(hfr)
+
         return kwargs
 
     """
@@ -602,3 +587,21 @@ class PipeTask(luigi.Task, PipeBase):
         """
         assert (isinstance(tags, dict))
         self.user_tags.update(tags)
+
+    def mark_output_transient(self):
+        """
+        Disdat Pipe API Function
+
+        Mark output bundle as transient.   This means that during execution Disdat will not
+        write (push) this bundle back to the remote.  That only happens in two cases:
+        1.) Started the pipeline with incremental_push=True
+        2.) Running the pipeline in a container with no_push or no_push_intermediates False
+
+        We mark the bundle with a tag.   Incremental push investigates the tag before pushing.
+        And the entrypoint investigates the tag if we are not pushing incrementally.
+        Otherwise, normal push commands from the CLI or api will work, i.e., manual pushes continue to work.
+
+        Returns:
+            None
+        """
+        self.add_tags({'transient_bundle': 'True'})

--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -588,7 +588,7 @@ class PipeTask(luigi.Task, PipeBase):
         assert (isinstance(tags, dict))
         self.user_tags.update(tags)
 
-    def mark_output_transient(self):
+    def mark_transient(self):
         """
         Disdat Pipe API Function
 

--- a/disdat/pipe_base.py
+++ b/disdat/pipe_base.py
@@ -412,11 +412,11 @@ class PipeBase(object):
         elif isinstance(val, dict):
             presentation = hyperframe_pb2.ROW
             for k, v in val.iteritems():
-                if False: # For now require dict values to be sequences
-                    if not isinstance(v, collections.Sequence):
-                        frames.append(DataContext.convert_scalar2frame(hfid, k, v, managed_path))
-                assert isinstance(v, (list, tuple, pd.core.series.Series, np.ndarray))
-                frames.append(DataContext.convert_serieslike2frame(hfid, k, v, managed_path))
+                if not isinstance(v, (list, tuple, pd.core.series.Series, np.ndarray, collections.Sequence)):
+                    frames.append(DataContext.convert_scalar2frame(hfid, k, v, managed_path))
+                else:
+                    assert isinstance(v, (list, tuple, pd.core.series.Series, np.ndarray, collections.Sequence))
+                    frames.append(DataContext.convert_serieslike2frame(hfid, k, v, managed_path))
 
         elif isinstance(val, pd.DataFrame):
             presentation = hyperframe_pb2.DF

--- a/disdat/pipe_base.py
+++ b/disdat/pipe_base.py
@@ -429,33 +429,6 @@ class PipeBase(object):
         return presentation, frames
 
     @staticmethod
-    def parse_api_return_val(hfid, val, data_context, bundle_inputs, bundle_name, bundle_processing_name, pipe):
-        """
-
-        Args:
-            hfid (str): UUID
-            val (?): Value to parse
-            data_context (DataContext): Context into which to place the data
-            bundle_inputs (list): The bundles used to create this bundle (lineage)
-            bundle_name (str): The human name of this bundle
-            bundle_processing_name (str): The more unique name of this bundle
-            pipe (PipeTask): The PipeTask that created this bundle.
-
-        Returns:
-            HyperFrameRecord
-
-        """
-
-        presentation, frames = PipeBase.parse_return_val(hfid, val, data_context)
-
-        hfr = PipeBase.make_hframe(frames, hfid, bundle_inputs,
-                                   bundle_name, bundle_processing_name, pipe,
-                                   tags={"presentable": "True"},
-                                   presentation=presentation)
-
-        return hfr
-
-    @staticmethod
     def parse_pipe_return_val(hfid, val, data_context, pipe):
         """
 
@@ -480,9 +453,9 @@ class PipeBase(object):
 
         """
 
-        return PipeBase.parse_api_return_val(hfid, val, data_context,
-                                             pipe.bundle_inputs(),
-                                             pipe.pipeline_id(),
-                                             pipe.pipe_id(),
-                                             pipe)
+        presentation, frames = PipeBase.parse_return_val(hfid, val, data_context)
 
+        return PipeBase.make_hframe(frames, hfid, pipe.bundle_inputs(),
+                                    pipe.pipeline_id(), pipe.pipe_id(), pipe,
+                                    tags={"presentable": "True"},
+                                    presentation=presentation)

--- a/examples/pipelines/test_inc_pull.py
+++ b/examples/pipelines/test_inc_pull.py
@@ -1,0 +1,120 @@
+#
+# Copyright 2017 Human Longevity, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Test Incremental Pull
+
+Use API to create a bundle with some files
+push to remote context (test assumes that you have AWS credentials for an account.
+
+author: Kenneth Yocum
+"""
+
+from disdat.pipe import PipeTask
+import disdat.api as api
+import luigi
+
+
+TEST_CONTEXT = '_test_context_'
+TEST_NAME    = 'example_bundle'
+REMOTE_URL   = 's3://disdat-prod-486026647292-us-west-2/beta/'
+
+
+"""
+Bundles have
+human_name
+processing_name
+set of tags
+date
+
+
+"""
+
+def test():
+    """
+
+    Returns:
+
+    """
+
+    contexts = api.ls_contexts()
+
+    if TEST_CONTEXT in contexts:
+        print "Test incremental pull failed as test context [{}] already exists.".format(TEST_CONTEXT)
+
+    api.context(TEST_CONTEXT)
+    api.remote(TEST_CONTEXT, TEST_CONTEXT, REMOTE_URL, force=True)
+
+    # Make Bundle, add files, close
+    with api.Bundle(TEST_CONTEXT, TEST_NAME) as b:
+        output = {'file':[],'name':[]}
+        for i in range(2):
+            with b.make_file('output_{}'.format(i)) as of:
+                of.write("some text for the {} file".format(i))
+                output['name'].append('output_{}'.format(i))
+                output['file'].append(of)
+        b.add_data(output)
+
+    b.push()
+
+    b.rm()
+
+    b = api.Bundle(TEST_CONTEXT, TEST_NAME).pull(localize=False)
+
+    b.set_processing_name(Bundle_Task())
+    # Now use this task as an external dependency.
+
+
+class ExternalDepWrapper(PipeTask):
+    """ Only to generate the processing name """
+    def pipe_requires(self, pipeline_input=None):
+        self.set_bundle_name()
+
+
+class ConsumeExtDep(PipeTask):
+    """ Consume files from an external dependency
+    """
+    num_luigi_files  = luigi.IntParameter(default=2)
+    num_dir_files    = luigi.IntParameter(default=2)
+
+    def pipe_requires(self, pipeline_input=None):
+        """ No new tasks
+        Returns:
+            None
+        """
+        self.add_external_dependency("input_files",
+                                     ExternalDepWrapper,
+                                     {})
+        return None
+
+    def pipe_run(self, pipeline_input=None, input_files=None):
+        """ For each file, print out its name and contents.
+        """
+        max_len = 0
+        nfiles = 0
+        for k, v in input_files.iteritems():
+            for f in v:
+                with open(f,'r') as of:
+                    s = of.read()
+                    if len(s) > max_len:
+                        max_len = len(s)
+                    print "Reading file: {} length:{}".format(f, len(s))
+                    nfiles += 1
+
+        return {'num categories': [len(input_files)], 'num files': [nfiles], 'max string': [max_len]}
+
+
+if __name__ == "__main__":
+    api.apply('examples', '-', '-', 'ReadFiles', params={'num_luigi_files':5})

--- a/examples/pipelines/test_inc_pull.py
+++ b/examples/pipelines/test_inc_pull.py
@@ -42,6 +42,7 @@ date
 
 """
 
+
 def test():
     """
 
@@ -61,10 +62,10 @@ def test():
     with api.Bundle(TEST_CONTEXT, TEST_NAME) as b:
         output = {'file':[],'name':[]}
         for i in range(2):
-            with b.make_file('output_{}'.format(i)) as of:
+            with b.make_file('output_{}'.format(i)).open('w') as of:
                 of.write("some text for the {} file".format(i))
                 output['name'].append('output_{}'.format(i))
-                output['file'].append(of)
+                output['file'].append(of.name)
         b.add_data(output)
 
     b.push()
@@ -73,8 +74,6 @@ def test():
 
     b = api.Bundle(TEST_CONTEXT, TEST_NAME).pull(localize=False)
 
-    b.set_processing_name(Bundle_Task())
-    # Now use this task as an external dependency.
 
 
 class ExternalDepWrapper(PipeTask):
@@ -117,4 +116,5 @@ class ConsumeExtDep(PipeTask):
 
 
 if __name__ == "__main__":
-    api.apply('examples', '-', '-', 'ReadFiles', params={'num_luigi_files':5})
+    test()
+    #api.apply('examples', '-', '-', 'ReadFiles', params={'num_luigi_files':5})

--- a/tests/test_external_bundle.py
+++ b/tests/test_external_bundle.py
@@ -18,17 +18,44 @@ import luigi
 import pandas as pd
 import numpy as np
 from disdat.pipe import PipeTask
+import disdat.api as api
 
-""" Purpose of this test is to have one task that produces a bundle.
-And another task that requires it. 
 
-1.) Create external dep -- also creates PreMaker_auf_datamaker
-dsdt apply - - test_external_bundle.DataMaker --int_array '[1000,2000,3000]'
-2.) Remove Premaker_auf_datamaker
-dsdt rm PreMaker_auf_datamaker
-3.) Try to run Root -- it should find DataMaker but not re-create it or PreMaker_auf_datamaker
+TEST_CONTEXT = '_test_context_'
+TEST_NAME    = 'test_bundle'
 
- """
+
+def test():
+    """ Purpose of this test is to have one task that produces a bundle.
+    And another task that requires it.
+
+    1.) Create external dep -- also creates PreMaker_auf_datamaker
+    dsdt apply - - test_external_bundle.DataMaker --int_array '[1000,2000,3000]'
+
+    2.) Remove Premaker_auf_datamaker
+    dsdt rm PreMaker_auf_datamaker
+
+    3.) Try to run Root -- it should find DataMaker but not re-create it or PreMaker_auf_datamaker
+
+    """
+
+    api.context(TEST_CONTEXT)
+
+    api.apply(TEST_CONTEXT, '-', '-', 'DataMaker', params={'int_array': '[1000,2000,3000]'})
+
+    b = api.get(TEST_CONTEXT, 'PreMaker_auf_datamaker')
+
+    assert(b is not None)
+
+    b.rm()
+
+    api.apply(TEST_CONTEXT, '-', '-', 'Root')
+
+    b = api.get(TEST_CONTEXT, 'PreMaker_auf_root')
+
+    assert(b is not None)
+
+    api.delete_context(TEST_CONTEXT)
 
 
 class DataMaker(PipeTask):
@@ -73,3 +100,7 @@ class Root(PipeTask):
         print ("Root received a datamaker {}".format(datamaker))
 
         return
+
+
+if __name__ == '__main__':
+    test()

--- a/tests/test_inc_pull.py
+++ b/tests/test_inc_pull.py
@@ -22,25 +22,14 @@ push to remote context (test assumes that you have AWS credentials for an accoun
 author: Kenneth Yocum
 """
 
+import getpass
 from disdat.pipe import PipeTask
 import disdat.api as api
-import luigi
 
 
 TEST_CONTEXT = '_test_context_'
-TEST_NAME    = 'example_bundle'
+TEST_NAME    = 'test_bundle'
 REMOTE_URL   = 's3://disdat-prod-486026647292-us-west-2/beta/'
-
-
-"""
-Bundles have
-human_name
-processing_name
-set of tags
-date
-
-
-"""
 
 
 def test():
@@ -50,71 +39,53 @@ def test():
 
     """
 
-    contexts = api.ls_contexts()
-
-    if TEST_CONTEXT in contexts:
-        print "Test incremental pull failed as test context [{}] already exists.".format(TEST_CONTEXT)
-
     api.context(TEST_CONTEXT)
     api.remote(TEST_CONTEXT, TEST_CONTEXT, REMOTE_URL, force=True)
 
-    # Make Bundle, add files, close
-    with api.Bundle(TEST_CONTEXT, TEST_NAME) as b:
-        output = {'file':[],'name':[]}
-        for i in range(2):
-            with b.make_file('output_{}'.format(i)).open('w') as of:
+    with api.Bundle(TEST_CONTEXT, TEST_NAME, owner=getpass.getuser()) as b:
+        for i in range(3):
+            with b.add_file('output_{}'.format(i)).open('w') as of:
                 of.write("some text for the {} file".format(i))
-                output['name'].append('output_{}'.format(i))
-                output['file'].append(of.name)
-        b.add_data(output)
 
-    b.push()
+    b.commit().push()
 
     b.rm()
 
-    b = api.Bundle(TEST_CONTEXT, TEST_NAME).pull(localize=False)
+    b.pull(localize=False)
 
+    api.apply(TEST_CONTEXT, '-', 'test_output', 'ConsumeExtDep', incremental_pull=True)
 
-
-class ExternalDepWrapper(PipeTask):
-    """ Only to generate the processing name """
-    def pipe_requires(self, pipeline_input=None):
-        self.set_bundle_name()
+    api.delete_context(TEST_CONTEXT, remote=True)
 
 
 class ConsumeExtDep(PipeTask):
     """ Consume files from an external dependency
     """
-    num_luigi_files  = luigi.IntParameter(default=2)
-    num_dir_files    = luigi.IntParameter(default=2)
 
     def pipe_requires(self, pipeline_input=None):
-        """ No new tasks
-        Returns:
-            None
+        """ We depend on a manually created bundle that
+        is parameterized by its name and its owner
         """
         self.add_external_dependency("input_files",
-                                     ExternalDepWrapper,
-                                     {})
-        return None
+                                     api.BundleWrapperTask,
+                                     {'name': TEST_NAME,
+                                      'owner': getpass.getuser()})
 
     def pipe_run(self, pipeline_input=None, input_files=None):
         """ For each file, print out its name and contents.
         """
         max_len = 0
         nfiles = 0
-        for k, v in input_files.iteritems():
-            for f in v:
-                with open(f,'r') as of:
-                    s = of.read()
-                    if len(s) > max_len:
-                        max_len = len(s)
-                    print "Reading file: {} length:{}".format(f, len(s))
-                    nfiles += 1
+        for v in input_files:
+            with open(v, 'r') as of:
+                s = of.read()
+                if len(s) > max_len:
+                    max_len = len(s)
+                print "Reading file: {} length:{}".format(v, len(s))
+                nfiles += 1
 
         return {'num categories': [len(input_files)], 'num files': [nfiles], 'max string': [max_len]}
 
 
 if __name__ == "__main__":
     test()
-    #api.apply('examples', '-', '-', 'ReadFiles', params={'num_luigi_files':5})


### PR DESCRIPTION
Fixes:
1.) delete_context now correctly removes frames from the sqlite db
2.) delete hyperframe now correctly uses passed in context, not current context
Features:
1.) Containerized pipelines pull non-localized bundles, then localize on demand as needed (lazy-pull)
2.) api.Bundle inherits from HyperFrameRecord.  
3.) Added API.ExternalWrapperTask to allow bundles created by the API to be found by Luigi tasks using self.add_dependency() 
4.) cat and api.cat() now return the actual bundle presentation (scalar, array, list, df), instead of coercing everything into a dataframe
5.) Add ability to set an output bundle as "transient".  Prevents the container from writing the bundle back to the remote context.   
6.) Added a test that makes a context, adds a remote, makes a bundle, deletes, pulls, runs a task that needs to use lazy pull to succeed, and then deletes local and remote contexts.