### PR TITLE
better transient support

### DIFF
--- a/disdat/common.py
+++ b/disdat/common.py
@@ -17,7 +17,6 @@
 Configuration
 """
 
-import json
 import logging
 import os
 import sys
@@ -48,6 +47,7 @@ BUNDLE_URI_SCHEME = 'bundle://'
 
 # Some tags in bundles are special.  They are prefixed with '__'
 BUNDLE_TAG_PARAMS_PREFIX = '__param_'
+BUNDLE_TAG_TRANSIENT = '__transient'
 
 
 class ApplyException(Exception):

--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -36,6 +36,7 @@ from disdat.pipe_base import PipeBase
 from disdat.db_target import DBTarget
 from disdat.driver import DriverTask
 from disdat.fs import DisdatFS
+from disdat.common import BUNDLE_TAG_TRANSIENT
 import luigi
 import logging
 import os
@@ -316,11 +317,9 @@ class PipeTask(luigi.Task, PipeBase):
 
             self.data_context.write_hframe(hfr)
 
-            transient = hfr.get_tag('transient_bundle')
-            if transient is not None and transient == "True":
+            transient = False
+            if hfr.get_tag(BUNDLE_TAG_TRANSIENT) is not None:
                 transient = True
-            else:
-                transient = False
 
             if self.incremental_push and not transient:
                 self.pfs.commit(None, None, uuid=pce.uuid, data_context=self.data_context)
@@ -604,4 +603,4 @@ class PipeTask(luigi.Task, PipeBase):
         Returns:
             None
         """
-        self.add_tags({'transient_bundle': 'True'})
+        self.add_tags({BUNDLE_TAG_TRANSIENT: 'True'})


### PR DESCRIPTION
Transient tag now a 'system' tag with a '_' prefix.
entrypoint now looks for transient when doing the final push of bundles to context.
removed un-used argument for json input bundle to run