### PR TITLE
dockerize fix pipeline sdist build

### DIFF
--- a/disdat/infrastructure/dockerizer/Makefile
+++ b/disdat/infrastructure/dockerizer/Makefile
@@ -185,8 +185,9 @@ $(DOCKER_CONTEXT)/disdat: $(DOCKER_CONTEXT) $(shell find $(DISDAT_ROOT)/disdat -
 # We assume the user has a setup.py that can create an sdist.
 $(DOCKER_CONTEXT)/pipeline: $(DOCKER_CONTEXT) $(shell find $(PIPELINE_ROOT) -not -path '*/\.*' -type f)
 	@echo "----- Copying pipeline $(PIPELINE_ROOT)"
-	python $(PIPELINE_ROOT)/setup.py sdist --dist-dir $@
-	@touch $@
+	cd $(PIPELINE_ROOT); \
+	    python $(PIPELINE_ROOT)/setup.py sdist --dist-dir $@; cd -
+	@touch $@/
 
 
 #

--- a/disdat/infrastructure/dockerizer/Makefile
+++ b/disdat/infrastructure/dockerizer/Makefile
@@ -187,7 +187,7 @@ $(DOCKER_CONTEXT)/pipeline: $(DOCKER_CONTEXT) $(shell find $(PIPELINE_ROOT) -not
 	@echo "----- Copying pipeline $(PIPELINE_ROOT)"
 	cd $(PIPELINE_ROOT); \
 	    python $(PIPELINE_ROOT)/setup.py sdist --dist-dir $@; cd -
-	@touch $@/
+	@touch $@
 
 
 #


### PR DESCRIPTION
Problem was creating an sdist from the user's pipeline through the dockerizer makefile.   It was calling `python <pipeline_root>/setup.py` but that returns different results depending on the directory in which it was called.   So now we `cd` to the pipeline_root first.  