### PR TITLE
More info when doing a fast pull, fix double printing log msgs, fix 

### DIFF
--- a/disdat/dsdt.py
+++ b/disdat/dsdt.py
@@ -56,7 +56,6 @@ def main():
 
     :return: (shape of input df, shape of pushed df)
     """
-    log.enable()  # TODO: Add configurable verbosity
 
     if getattr(sys, 'frozen', False):
         here = os.path.join(sys._MEIPASS, 'disdat')
@@ -113,10 +112,11 @@ def main():
 
     args = parser.parse_args(args)
 
-    log_level = logging.WARN
+    log_level = logging.INFO
     if args.verbose:
         log_level = logging.DEBUG
-    logging.basicConfig(level=log_level)
+
+    log.enable(level=log_level)  # TODO: Add configurable verbosity
 
     if args.aws_profile is not None:
         os.environ['AWS_PROFILE'] = args.aws_profile


### PR DESCRIPTION
Print out more info when doing a pull.   
Remove vistigial call to logger to remove double outputs.
Updated `dsdt context` output so we just print the s3 bucket. 