### PR TITLE
dsdt init failing with new logging

### DIFF
--- a/disdat/common.py
+++ b/disdat/common.py
@@ -221,8 +221,6 @@ class DisdatConfig(object):
         luigi_dir = os.path.join(directory, LUIGI_FILE)
         config = configparser.ConfigParser()
         config.read(luigi_dir)
-        value = config.get('core', 'logging_conf_file')
-        config.set('core', 'logging_conf_file', os.path.expanduser(value))
         with open(luigi_dir, 'w') as handle:
             config.write(handle)
 


### PR DESCRIPTION
Initialization was still looking for a logging_conf_file in the luigi.cfg.  We no longer use a logging configuration file.   