### PR TITLE
Changes to container naming and credential usage

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -54,7 +54,6 @@ disdat.fs.DisdatConfig.instance()
 
 fs = disdat.fs.DisdatFS()
 
-
 def set_aws_profile(aws_profile):
     os.environ['AWS_PROFILE'] = aws_profile
 
@@ -238,6 +237,7 @@ class Bundle(HyperFrameRecord):
             _logger.warn("Bundle is already open.")
             return
         elif not self.closed:
+
             self.local_dir, self.pb.uuid, self.remote_dir = self.data_context.make_managed_path()
             self.open = True
         else:

--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -243,7 +243,7 @@ class DataContext(object):
         files = glob.glob(os.path.join(ctxt_dir, '*'))
 
         for ctxt in files:
-            _logger.debug("Loading context {}...".format(ctxt))
+            #_logger.debug("Loading context {}...".format(ctxt))
             meta_file = os.path.join(ctxt_dir, ctxt, META_CTXT_FILE)
 
             if not os.path.isfile(meta_file):

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -212,15 +212,18 @@ def profile_get_region():
                 return _get_region(profiles, profile_name)
             except KeyError:
                 return None
-    session = b3.session()
-    if 'AWS_PROFILE' in os.environ:
-        profile_name = os.environ['AWS_PROFILE']
-    else:
-        profile_name = 'default'
-    profiles = session.full_config['profiles']
-    region = _get_region(profiles, profile_name)
+
+    # ENV variables take precedence over the region in the ~/.aws/ folder
     if 'AWS_DEFAULT_REGION' in os.environ:
         region = os.environ['AWS_DEFAULT_REGION']
+    else:
+        session = b3.session()
+        if 'AWS_PROFILE' in os.environ:
+            profile_name = os.environ['AWS_PROFILE']
+        else:
+            profile_name = 'default'
+        profiles = session.full_config['profiles']
+        region = _get_region(profiles, profile_name)
     return region
 
 

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -169,12 +169,14 @@ def ecr_create_fq_respository_name(repository_name, policy_resource_package=None
                 repositoryNames=[repository_name]
             )
             repository_metadata = response['repositories'][0]
+        elif e.response['Error']['Code'] == 'AccessDeniedException':
+            _logger.warn("Error [AccessDeniedException] when creating repo {}, trying to continue...".format(repository_name))
         else:
             raise e
     return repository_metadata['repositoryUri']
 
 
-def ecr_get_fq_respository_name(repository_name):
+def ecr_get_fq_repository_name(repository_name):
     return ecr_create_fq_respository_name(repository_name)
 
 


### PR DESCRIPTION
1.) Allow user to specific container repository name
2.) If, on `dsdt run`, the user has a token, try to use the token. 