### PR TITLE
Single container per setup.py

### DIFF
--- a/disdat/common.py
+++ b/disdat/common.py
@@ -229,6 +229,7 @@ class DisdatConfig(object):
 # subprocess wrapper
 #
 
+
 def do_subprocess(cmd, cli):
     """ Standardize error processing
 
@@ -451,3 +452,12 @@ def slicezip(a, b):
     result[::2] = a
     result[1::2] = b
     return result
+
+
+def setup_exists(fqp_setup):
+    """ Check if file exists
+    """
+    if not os.path.exists(fqp_setup):
+        print ("No setup.py found at {}.".format(fqp_setup))
+        return False
+    return True

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -21,6 +21,7 @@ import logging
 import os
 import sys
 import shutil
+import subprocess
 
 import luigi
 from six.moves import urllib
@@ -224,10 +225,99 @@ class DisdatConfig(object):
         with open(luigi_dir, 'w') as handle:
             config.write(handle)
 
+#
+# subprocess wrapper
+#
+
+def do_subprocess(cmd, cli):
+    """ Standardize error processing
+
+    Args:
+        cmd (str): command to execute
+        cli (bool): whether called from CLI (True) or API (False)
+
+    Returns:
+        (int): 0 if success, >0 if failure
+
+    """
+    output = 'No captured output from running CMD [{}]'.format(cmd)
+    try:
+        if not cli:
+            output = subprocess.check_output(cmd)
+        else:
+            subprocess.check_call(cmd)
+    except subprocess.CalledProcessError as cpe:
+        if not cli:
+            print (output)
+            return cpe.returncode
+        raise
+
+    return 0
+
+
+def do_subprocess_with_output(cmd):
+    """ Standardize error processing
+
+    Args:
+        cmd (str): command to execute
+
+    Returns:
+        (str): output of command
+
+    """
+    try:
+        output = subprocess.check_output(cmd)
+        return output
+    except subprocess.CalledProcessError as cpe:
+        raise
 
 #
 # Make Docker images names from pipeline class names
 #
+
+
+def make_project_image_name(setup_file_path):
+    """
+    Create a container name from the name field in the setup.py file.
+    This uses some setuptools magic.  When you install disdat, we install
+    an entrypoint.   It becomes available to anyone using setup tools.
+    This extracts the information from the setup.py.
+
+    see disdat/infrastructure/dockerizer/setup_tools_commands.py
+
+    Args:
+        setup_file_path (str): The FQP to the setup.py file used to dockerize.
+
+    Returns:
+        (str): image name string
+
+    """
+
+    python_command = [
+        'python',
+        setup_file_path,
+        '-q',
+        'dsdt_distname'
+    ]
+
+    retval = do_subprocess_with_output(python_command).strip()
+
+    return retval
+
+
+def make_sagemaker_project_image_name(setup_file_path):
+    """ Create the string for the image for this pipeline if it uses sagemaker's
+    calling convention
+
+    Args:
+        setup_file_path (str): The FQP to the setup.py file used to dockerize
+
+    Returns:
+        str: The name of the image + '-sagemaker'
+    """
+
+    return make_project_image_name(setup_file_path) + "-sagemaker"
+
 
 def make_pipeline_image_name(pipeline_class_name):
     """ Create the string for the image for this pipeline_class_name
@@ -264,6 +354,14 @@ def make_pipeline_repository_name(docker_repository_prefix, pipeline_class_name)
 
 def make_sagemaker_pipeline_repository_name(docker_repository_prefix, pipeline_class_name):
     return '/'.join(([docker_repository_prefix.strip('/')] if docker_repository_prefix is not None else []) + [make_sagemaker_pipeline_image_name(pipeline_class_name)])
+
+
+def make_project_repository_name(docker_repository_prefix, setup_file_path):
+    return '/'.join(([docker_repository_prefix.strip('/')] if docker_repository_prefix is not None else []) + [make_project_image_name(setup_file_path)])
+
+
+def make_sagemaker_project_repository_name(docker_repository_prefix, setup_file_path):
+    return '/'.join(([docker_repository_prefix.strip('/')] if docker_repository_prefix is not None else []) + [make_sagemaker_project_image_name(setup_file_path)])
 
 
 #

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -343,6 +343,7 @@ def get_run_command_parameters(pfs):
 def make_run_command(
         output_bundle,
         output_bundle_uuid,
+        pipe_cls,
         remote,
         context,
         input_tags,
@@ -358,7 +359,8 @@ def make_run_command(
         '--output-bundle-uuid ', output_bundle_uuid,
         '--remote', remote,
         '--branch', context,
-        '--workers', str(workers)
+        '--workers', str(workers),
+        '--pipeline', str(pipe_cls)
     ]
     if no_pull:
         args += ['--no-pull']

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -319,43 +319,6 @@ def make_sagemaker_project_image_name(setup_file_path):
     return make_project_image_name(setup_file_path) + "-sagemaker"
 
 
-def make_pipeline_image_name(pipeline_class_name):
-    """ Create the string for the image for this pipeline_class_name
-
-    'disdat-module[-submodule]...'
-
-    Args:
-        pipeline_class_name:
-
-    Returns:
-        str: The name of the image 'disdat-module[-submodule]...'
-    """
-
-    return '-'.join(['disdat'] + pipeline_class_name.split('.')[:-1]).lower()
-
-
-def make_sagemaker_pipeline_image_name(pipeline_class_name):
-    """ Create the string for the image for this pipeline if it uses sagemaker's
-    calling convention
-
-    Args:
-        pipeline_class_name:
-
-    Returns:
-        str: The name of the image 'disdat-module[-submodule]...-sagemaker'
-    """
-
-    return make_pipeline_image_name(pipeline_class_name) + "-sagemaker"
-
-
-def make_pipeline_repository_name(docker_repository_prefix, pipeline_class_name):
-    return '/'.join(([docker_repository_prefix.strip('/')] if docker_repository_prefix is not None else []) + [make_pipeline_image_name(pipeline_class_name)])
-
-
-def make_sagemaker_pipeline_repository_name(docker_repository_prefix, pipeline_class_name):
-    return '/'.join(([docker_repository_prefix.strip('/')] if docker_repository_prefix is not None else []) + [make_sagemaker_pipeline_image_name(pipeline_class_name)])
-
-
 def make_project_repository_name(docker_repository_prefix, setup_file_path):
     return '/'.join(([docker_repository_prefix.strip('/')] if docker_repository_prefix is not None else []) + [make_project_image_name(setup_file_path)])
 

--- a/disdat/dockerize.py
+++ b/disdat/dockerize.py
@@ -295,7 +295,7 @@ def add_arg_parser(parsers):
         dest='build',
     )
     dockerize_p.add_argument(
-        "pipe_root",
+        "pipeline_root",
         type=str,
         help="Root of the Python source tree containing the user-defined transform; must have a setuptools-style setup.py file"
     )
@@ -315,9 +315,9 @@ def dockerize_entry(cli=False, **kwargs):
     """
 
     if kwargs['get_id']:
-        return latest_container_id(kwargs['pipe_root'], cli)
+        return latest_container_id(kwargs['pipeline_root'], cli)
     else:
-        return dockerize(kwargs['pipe_root'],
+        return dockerize(kwargs['pipeline_root'],
                          config_dir=kwargs['config_dir'],
                          os_type=kwargs['os_type'],
                          os_version=kwargs['os_version'],

--- a/disdat/dockerize.py
+++ b/disdat/dockerize.py
@@ -170,6 +170,10 @@ def dockerize(pipeline_root,
     if retval: return retval
 
     setup_file = os.path.join(pipeline_root, 'setup.py')
+
+    if not disdat.common.setup_exists(setup_file):
+        return 1
+
     pipeline_image_name = disdat.common.make_project_image_name(setup_file)
 
     DEFAULT_DISDAT_HOME = os.path.join('/', *os.path.dirname(disdat.dockerize.__file__).split('/')[:-1])

--- a/disdat/dockerize.py
+++ b/disdat/dockerize.py
@@ -19,7 +19,6 @@ from __future__ import print_function
 import inspect
 import logging
 import os
-import subprocess
 import tempfile
 import shutil
 
@@ -38,34 +37,40 @@ _DOCKERIZER_ROOT = os.path.dirname(inspect.getsourcefile(dockerizer))
 _logger = logging.getLogger(__name__)
 
 
-def _do_subprocess(cmd, cli):
-    """ Standardize error processing
+def _copy_in_dot_file(disdat_config, docker_context, dot_file_name, option_name, cli):
+    """
+    Copy in a dot file to a file with name "dot_file_name" into the docker context.
+    The user might have put the src path in the disdat config file under the "option_name"
 
     Args:
-        cmd (str): command to execute
-        cli (bool): whether called from CLI (True) or API (False)
+        disdat_config:  A disdat config object
+        docker_context:  The place we are storing the docker context for build
+        dot_file_name:  The name of the file in the docker context
+        option_name: the name of the option in disdat.cfg
+        cli (bool): whether we are called from cli
 
     Returns:
-        (int): 0 if success, >0 if failure
+        None or if subprocess has output
 
     """
-    output = 'No captured output from running CMD [{}]'.format(cmd)
-    try:
-        if not cli:
-            output = subprocess.check_output(cmd)
-        else:
-            subprocess.check_call(cmd)
-    except subprocess.CalledProcessError as cpe:
-        if not cli:
-            print (output)
-            return cpe.returncode
-        raise
+    retval = 0
 
-    return 0
+    dot_file_path = os.path.join(docker_context, dot_file_name)
+    if disdat_config.parser.has_option(_MODULE_NAME, option_name):
+        dot_file = os.path.expanduser(disdat_config.parser.get(_MODULE_NAME, option_name))
+        shutil.copy(dot_file, dot_file_path)
+        print("Copying dot file {} into {}".format(dot_file, docker_context))
+    else:
+        touch_command = [
+            'touch',
+            dot_file_path
+        ]
+        retval = disdat.common.do_subprocess(touch_command, cli)
+
+    return retval
 
 
 def dockerize(pipeline_root,
-              pipeline_class_name,
               config_dir=None,
               os_type=None,
               os_version=None,
@@ -78,8 +83,7 @@ def dockerize(pipeline_root,
 
     Args:
         pipeline_root: Root of the Python source tree containing the
-        user-defined transform; must have a setuptools-style setup.py file.
-        pipeline_class_name: The fully-qualified name of the pipeline
+        setuptools-style setup.py file.
         config_dir (str):  Configuration of image (.deb, requires.txt, etc.)
         os_type (str): OS type string
         os_version (str): Version of OS
@@ -116,42 +120,24 @@ def dockerize(pipeline_root,
         docker_context,
     ]
 
-    retval = _do_subprocess(rsync_command, cli)
+    retval = disdat.common.do_subprocess(rsync_command, cli)
     if retval: return retval
 
     # PIP: Overwrite pip.conf in the context.template in your repo if they have set the option,
     # else just create empty file.
     # At this time, the Dockerfile always sets the PIP_CONFIG_FILE ENV var to this file.
-    pip_file_path = os.path.join(docker_context, "pip.conf")
-    if disdat_config.parser.has_option(_MODULE_NAME, 'dot_pip_file'):
-        dot_pip_file = os.path.expanduser(disdat_config.parser.get(_MODULE_NAME, 'dot_pip_file'))
-        shutil.copy(dot_pip_file, pip_file_path)
-        print("Copying dot pip file {} into {}".format(dot_pip_file, docker_context))
-    else:
-        touch_command = [
-            'touch',
-            pip_file_path
-        ]
-        retval = _do_subprocess(touch_command, cli)
-        if retval: return retval
+    retval = _copy_in_dot_file(disdat_config, docker_context, "pip.conf", "dot_pip_file", cli)
+    if retval: return retval
 
     # ODBC: Overwrite the .odbc.ini in the context.template in your repo if the user set the option,
     # else just create empty file.
     # At this time, the Dockerfile always sets the ODBCINI var to this file.
-    odbc_file_path = os.path.join(docker_context,"odbc.ini")
-    if disdat_config.parser.has_option(_MODULE_NAME, 'dot_odbc_ini_file'):
-        dot_odbc_ini_file = os.path.expanduser(disdat_config.parser.get(_MODULE_NAME, 'dot_odbc_ini_file'))
-        shutil.copy(dot_odbc_ini_file, odbc_file_path)
-        print("Copying dot odbc.ini file {} into {}".format(dot_odbc_ini_file, odbc_file_path))
-    else:
-        touch_command = [
-            'touch',
-            odbc_file_path
-        ]
-        retval = _do_subprocess(touch_command, cli)
-        if retval: return retval
+    retval = _copy_in_dot_file(disdat_config, docker_context, "odbc.ini", "dot_odbc_ini_file", cli)
+    if retval: return retval
 
-    pipeline_image_name = disdat.common.make_pipeline_image_name(pipeline_class_name)
+    setup_file = os.path.join(pipeline_root, 'setup.py')
+    pipeline_image_name = disdat.common.make_project_image_name(setup_file)
+
     DEFAULT_DISDAT_HOME = os.path.join('/', *os.path.dirname(disdat.dockerize.__file__).split('/')[:-1])
     DISDAT_HOME = os.getenv('DISDAT_HOME', DEFAULT_DISDAT_HOME)
 
@@ -163,16 +149,16 @@ def dockerize(pipeline_root,
             'DOCKER_CONTEXT={}'.format(docker_context),
             'DISDAT_ROOT={}'.format(os.path.join(DISDAT_HOME)),  # XXX YUCK
             'PIPELINE_ROOT={}'.format(pipeline_root),
-            'PIPELINE_CLASS={}'.format(pipeline_class_name),
+            'PIPELINE_CLASS=DEPRECATED_STUFF',
             'OS_TYPE={}'.format(image_os_type),
             'OS_VERSION={}'.format(image_os_version),
         ]
         if config_dir is not None:
             build_command.append('CONFIG_ROOT={}'.format(config_dir))
         if sagemaker:
-            build_command.append('SAGEMAKER_TRAIN_IMAGE_NAME={}'.format(disdat.common.make_sagemaker_pipeline_image_name(pipeline_class_name)))
+            build_command.append('SAGEMAKER_TRAIN_IMAGE_NAME={}'.format(disdat.common.make_sagemaker_project_image_name(setup_file)))
             build_command.append('sagemaker')
-        retval = _do_subprocess(build_command, cli)
+        retval = disdat.common.do_subprocess(build_command, cli)
         if retval: return retval
 
     if push:
@@ -185,10 +171,10 @@ def dockerize(pipeline_root,
             if disdat_config.parser.has_option('docker', 'repository_prefix'):
                 repository_name_prefix = disdat_config.parser.get('docker', 'repository_prefix')
             if sagemaker:
-                repository_name = disdat.common.make_sagemaker_pipeline_repository_name(repository_name_prefix, pipeline_class_name)
-                pipeline_image_name = disdat.common.make_sagemaker_pipeline_image_name(pipeline_class_name)
+                repository_name = disdat.common.make_sagemaker_project_repository_name(repository_name_prefix, setup_file)
+                pipeline_image_name = disdat.common.make_sagemaker_project_image_name(setup_file)
             else:
-                repository_name = disdat.common.make_pipeline_repository_name(repository_name_prefix, pipeline_class_name)
+                repository_name = disdat.common.make_project_repository_name(repository_name_prefix, setup_file)
 
             # Figure out the fully-qualified repository name, i.e., the name
             # including the registry.
@@ -275,7 +261,6 @@ def add_arg_parser(parsers):
         type=str,
         help="Root of the Python source tree containing the user-defined transform; must have a setuptools-style setup.py file"
     )
-    dockerize_p.add_argument("pipe_cls", type=str, help="User-defined transform, e.g., module.PipeClass")
     dockerize_p.set_defaults(func=lambda args: dockerize_entry(cli=True, **vars(args)))
     return parsers
 
@@ -292,7 +277,6 @@ def dockerize_entry(cli=False, **kwargs):
     """
 
     return dockerize(kwargs['pipe_root'],
-                     kwargs['pipe_cls'],
                      config_dir=kwargs['config_dir'],
                      os_type=kwargs['os_type'],
                      os_version=kwargs['os_version'],

--- a/disdat/infrastructure/dockerizer/Makefile
+++ b/disdat/infrastructure/dockerizer/Makefile
@@ -39,13 +39,10 @@ ifeq ($(DOCKER_CONTEXT_TEMPLATE), )
 $(error DOCKER_CONTEXT_TEMPLATE variable not set or invalid)
 endif
 
-# The source root and class name of the pipeline to run
+# The source root of the pipeline to run
 PIPELINE_ROOT := $(shell echo $(PIPELINE_ROOT) | sed 's/\/*$$//')
 ifeq ($(PIPELINE_ROOT), )
 $(error PIPELINE_ROOT variable not set or invalid)
-endif
-ifeq ($(PIPELINE_CLASS), )
-$(error PIPELINE_CLASS variable not set)
 endif
 
 # Declare the base operating system to use
@@ -141,7 +138,6 @@ build-02: $(DOCKER_CONTEXT) $(DOCKER_CONTEXT)/config $(DOCKER_CONTEXT)/pipeline
 		--build-arg OS_NAME=$(OS_NAME) \
 		--build-arg IMAGE_LAYER=$(IMAGE_01_LAYER) \
 		--build-arg PIPELINE_ROOT=$(IMAGE_PIPELINE_ROOT) \
-		--build-arg PIPELINE_CLASS=$(PIPELINE_CLASS) \
 		--file $(DOCKER_CONTEXT)/Dockerfiles/02-user.dockerfile \
 		--tag $(PIPELINE_IMAGE_NAME) \
 		$(DOCKER_CONTEXT)

--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
@@ -63,11 +63,6 @@ fi
 # Clean up the temporary build directory
 RUN rm -rf $BUILD_ROOT
 
-# Set the pipeline execution parameters
-
-ARG PIPELINE_CLASS
-ENV PIPELINE_CLASS $PIPELINE_CLASS
-
 # Set up the default entry point. If the user starts an image with no
 # arguments, show some help
 COPY bin/entrypoint.py /opt/bin/entrypoint.py

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -269,10 +269,13 @@ def run_disdat_container(args):
 
 
 def main(input_args):
-    # To simplify configuring and building pipeline images, we keep all
-    # of the various defaults parameter values in the Docker image makefile,
-    # and pass them on as Docker ENV variables.
-    _pipeline_class_default = os.environ[_PIPELINE_CLASS_ENVVAR] if _PIPELINE_CLASS_ENVVAR in os.environ else None
+
+    # To simplify configuring and building pipeline images, we can keep
+    # various default parameter values in the Docker image makefile,
+    # and pass them on as Docker ENV variables.   At the moment, we set
+    # the default params below to handle most cases.  This is an example
+    # of how you might do this in the future if needed.
+    # some_default = os.environ[_YOURVAR_ENVVAR] if _YOURVAR_ENVVAR in os.environ else None
 
     parser = argparse.ArgumentParser(
         description=_HELP,
@@ -315,10 +318,10 @@ def main(input_args):
     pipeline_parser = parser.add_argument_group('pipe arguments')
     pipeline_parser.add_argument(
         '--pipeline',
-        default=_pipeline_class_default,
+        default=None,
         type=str,
-        required=(_pipeline_class_default is None),
-        help=add_argument_help_string('Name of the pipeline class to run', _pipeline_class_default),
+        required=True,
+        help=add_argument_help_string('Name of the pipeline class to run'),
     )
 
     pipeline_parser.add_argument(

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -20,9 +20,6 @@ import sys
 import boto3
 from botocore.exceptions import ClientError
 
-_PIPELINE_CLASS_ENVVAR = 'PIPELINE_CLASS'
-
-
 _HELP = """ Run a Disdat pipeline. This script wraps up several of the
 steps required to run a pipeline, including: creating a working context, 
 running a pipeline class to generate an output bundle, and pushing an 
@@ -275,7 +272,7 @@ def main(input_args):
     # and pass them on as Docker ENV variables.   At the moment, we set
     # the default params below to handle most cases.  This is an example
     # of how you might do this in the future if needed.
-    # some_default = os.environ[_YOURVAR_ENVVAR] if _YOURVAR_ENVVAR in os.environ else None
+    # some_default = os.environ[ENVVAR] if ENVVAR in os.environ else None
 
     parser = argparse.ArgumentParser(
         description=_HELP,

--- a/disdat/infrastructure/dockerizer/setup_tools_commands.py
+++ b/disdat/infrastructure/dockerizer/setup_tools_commands.py
@@ -1,0 +1,31 @@
+#
+# Copyright 2015, 2016, 2017, 2018, 2019 Human Longevity, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from distutils.core import Command
+
+
+class DistributionName(Command):
+
+    user_options = []
+
+    def initialize_options(self):
+        pass
+
+    def finalize_options(self):
+        pass
+
+    def run(self):
+        print(self.distribution.metadata.name)

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -68,11 +68,12 @@ class Backend(Enum):
         return [i.name for i in list(Backend)]
 
 
-def _run_local(cli, arglist, pipeline_class_name, backend):
+def _run_local(cli, pipeline_setup_file, arglist, pipeline_class_name, backend):
     """
     Run container locally or run sagemaker container locally
     Args:
         cli (bool): Whether we were called from the CLI or API
+        pipeline_setup_file (str): The FQ path to the setup.py used to dockerize the pipeline.
         arglist:
         pipeline_class_name:
         backend:
@@ -104,7 +105,7 @@ def _run_local(cli, arglist, pipeline_class_name, backend):
 
     try:
         if backend == Backend.LocalSageMaker:
-            pipeline_image_name = common.make_sagemaker_pipeline_image_name(pipeline_class_name)
+            pipeline_image_name = common.make_sagemaker_project_image_name(pipeline_setup_file)
             tempdir = tempfile.mkdtemp()
             with open(os.path.join(tempdir, 'hyperparameters.json'), 'w') as of:
                 json.dump(_sagemaker_hyperparameters_from_arglist(arglist), of)
@@ -118,7 +119,7 @@ def _run_local(cli, arglist, pipeline_class_name, backend):
                 volumes[localdir] = {'bind': '/opt/ml/input/config/', 'mode': 'rw'}
                 _logger.info("VOLUMES: {}".format(volumes))
         else:
-            pipeline_image_name = common.make_pipeline_image_name(pipeline_class_name)
+            pipeline_image_name = common.make_project_image_name(pipeline_setup_file)
 
         _logger.debug('Running image {} with arguments {}'.format(pipeline_image_name, arglist))
 
@@ -131,13 +132,13 @@ def _run_local(cli, arglist, pipeline_class_name, backend):
         return None
 
 
-def get_fq_docker_repo_name(is_sagemaker, pipeline_class_name):
+def get_fq_docker_repo_name(is_sagemaker, pipeline_setup_file):
     """
     Produce the fully qualified docker repo name.
 
     Args:
         is_sagemaker (bool): for sagemaker image
-        pipeline_class_name (str): the package.module.class string
+        pipeline_setup_file (str): the path to the setup.py file used to dockerize this pipeline
 
     Returns:
         (str): The fully qualified docker image repository name
@@ -148,9 +149,9 @@ def get_fq_docker_repo_name(is_sagemaker, pipeline_class_name):
     if disdat_config.parser.has_option('docker', 'repository_prefix'):
         repository_prefix = disdat_config.parser.get('docker', 'repository_prefix')
     if is_sagemaker:
-        repository_name = common.make_sagemaker_pipeline_repository_name(repository_prefix, pipeline_class_name)
+        repository_name = common.make_sagemaker_project_repository_name(repository_prefix, pipeline_setup_file)
     else:
-        repository_name = common.make_pipeline_repository_name(repository_prefix, pipeline_class_name)
+        repository_name = common.make_project_repository_name(repository_prefix, pipeline_setup_file)
 
     # Figure out the fully-qualified repository name, i.e., the name
     # including the registry.
@@ -163,7 +164,7 @@ def get_fq_docker_repo_name(is_sagemaker, pipeline_class_name):
     return fq_repository_name
 
 
-def _run_aws_batch(arglist, job_name, pipeline_class_name,
+def _run_aws_batch(arglist, fq_repository_name, job_name, pipeline_image_name,
                    aws_session_token_duration, vcpus, memory,
                    no_submit, job_role_arn):
     """
@@ -173,7 +174,9 @@ def _run_aws_batch(arglist, job_name, pipeline_class_name,
 
     Args:
         arglist:
-        pipeline_class_name:
+        fq_repository_name (str): The fully qualified docker repository name
+        job_name:
+        pipeline_image_name:
         aws_session_token_duration:
         vcpus:
         memory:
@@ -214,9 +217,7 @@ def _run_aws_batch(arglist, job_name, pipeline_class_name,
     # In addition, we never re-use a job definition, since the user may update
     # the vcpu or memory requirements and those are stuck in the job definition
 
-    fq_repository_name = get_fq_docker_repo_name(False, pipeline_class_name)
-
-    job_definition_name = aws.batch_get_job_definition_name(pipeline_class_name)
+    job_definition_name = aws.batch_get_job_definition_name(pipeline_image_name)
 
     if disdat_config.parser.has_option(_MODULE_NAME, 'aws_batch_job_definition'):
         job_definition_name = disdat_config.parser.get(_MODULE_NAME, 'aws_batch_job_definition')
@@ -284,20 +285,9 @@ def _run_aws_batch(arglist, job_name, pipeline_class_name,
                 {'name': 'AWS_SESSION_TOKEN', 'value': credentials.token}
             ]
 
-
-
-
-    if aws_session_token_duration > 0 and job_role_arn is None:
-        sts_client = b3.client('sts')
-        token = sts_client.get_session_token(DurationSeconds=aws_session_token_duration)
-        credentials = token['Credentials']
-        container_overrides['environment'] = [
-            {'name': 'AWS_ACCESS_KEY_ID', 'value': credentials['AccessKeyId']},
-            {'name': 'AWS_SECRET_ACCESS_KEY', 'value': credentials['SecretAccessKey']},
-            {'name': 'AWS_SESSION_TOKEN', 'value': credentials['SessionToken']}
-        ]
     job = client.submit_job(jobName=job_name, jobDefinition=job_definition_fqn, jobQueue=job_queue,
                             containerOverrides=container_overrides)
+
     status = job['ResponseMetadata']['HTTPStatusCode']
     if status == 200:
         _logger.info('Job {} (ID {}) with definition {} submitted to AWS Batch queue {}'.format(job['jobName'], job['jobId'],
@@ -306,6 +296,7 @@ def _run_aws_batch(arglist, job_name, pipeline_class_name,
     else:
         _logger.error('Job submission failed: HTTP Status {}'.format())
         return None
+
 
 def _sagemaker_hyperparameters_from_arglist(arglist):
     """
@@ -322,13 +313,16 @@ def _sagemaker_hyperparameters_from_arglist(arglist):
     return {'arglist': json.dumps(arglist)}
 
 
-def _run_aws_sagemaker(arglist, job_name, pipeline_class_name):
+def _run_aws_sagemaker(arglist, fq_repository_name, job_name, pipeline_class_name):
     """
     Runs a training job on AWS SageMaker.  This uses the default machine type
     in the disdat.cfg file.
 
     Args:
-        cli (bool): Whether we were called from the CLI or API
+        arglist:
+        fq_repository_name (str): fully qualified repository name
+        job_name:  instance job name
+        pipeline_class_name: The package.module.class Disdat task we are executing.
 
     Returns:
         TrainingJobArn (str)
@@ -339,8 +333,6 @@ def _run_aws_sagemaker(arglist, job_name, pipeline_class_name):
     job_name = job_name.replace('_', '-') # b/c SageMaker complains it must be ^[a-zA-Z0-9](-*[a-zA-Z0-9])*
 
     hyperparameter_dict = _sagemaker_hyperparameters_from_arglist(arglist)
-
-    fq_repository_name = get_fq_docker_repo_name(True, pipeline_class_name)
 
     algorithm_specification = {'TrainingImage': fq_repository_name,
                                'TrainingInputMode': 'File'}
@@ -403,7 +395,6 @@ def _run_aws_sagemaker(arglist, job_name, pipeline_class_name):
         InputDataConfig=input_channel_config,
         OutputDataConfig=output_data_config,
         ResourceConfig=resource_config,
-        #VpcConfig=vpc_config,
         StoppingCondition=stopping_condition,
         Tags=tags
     )
@@ -414,7 +405,8 @@ def _run_aws_sagemaker(arglist, job_name, pipeline_class_name):
 
 def _run(
         output_bundle = '-',
-        pipeline_args ='',
+        pipeline_root = '',
+        pipeline_args = '',
         pipe_cls = None,
         backend = None,
         input_tags = {},
@@ -438,6 +430,7 @@ def _run(
 
     Args:
         output_bundle (str): The human name of the output bundle
+        pipeline_root (str): The path to the setup.py used to create the container
         pipeline_args: Optional arguments to pass to the pipeline class
         pipe_cls: Name of the pipeline class to run
         backend: The batch execution back-end to use (default
@@ -464,6 +457,8 @@ def _run(
 
     pfs = fs.DisdatFS()
 
+    pipeline_setup_file = os.path.join(pipeline_root, 'setup.py')
+
     try:
         output_bundle_uuid = pfs.disdat_uuid()
         if remote is None or context is None:
@@ -473,26 +468,40 @@ def _run(
         _logger.error("'run' requires a remote set with `dsdt remote <s3 url>`")
         return
 
-    arglist = common.make_run_command(output_bundle, output_bundle_uuid, remote, context,
+    arglist = common.make_run_command(output_bundle, output_bundle_uuid, pipe_cls, remote, context,
                                       input_tags, output_tags, force, no_pull, no_push,
                                       no_push_int, workers, pipeline_args)
 
     if backend == Backend.AWSBatch or backend == Backend.SageMaker:
 
-        pipeline_image_name = common.make_pipeline_image_name(pipe_cls)
+        pipeline_image_name = common.make_project_image_name(pipeline_setup_file)
 
         job_name = '{}-{}'.format(pipeline_image_name, int(time.time()))
 
+        fq_repository_name = get_fq_docker_repo_name(False, pipeline_setup_file)
+
         if backend == Backend.AWSBatch:
-            retval = _run_aws_batch(arglist, job_name, pipe_cls,
-                           aws_session_token_duration, vcpus, memory,
-                           no_submit, job_role_arn)
+
+            retval = _run_aws_batch(arglist,
+                                    fq_repository_name,
+                                    job_name,
+                                    pipeline_image_name,
+                                    aws_session_token_duration,
+                                    vcpus,
+                                    memory,
+                                    no_submit,
+                                    job_role_arn)
         else:
-            retval = _run_aws_sagemaker(arglist, job_name, pipe_cls)
+
+            fq_repository_name = get_fq_docker_repo_name(True, pipeline_root)
+
+            retval = _run_aws_sagemaker(arglist,
+                                        fq_repository_name,
+                                        job_name,
+                                        pipe_cls)
 
     elif backend == Backend.Local or backend == Backend.LocalSageMaker:
-
-        retval = _run_local(cli, arglist, pipe_cls, backend)
+        retval = _run_local(cli, pipeline_setup_file, arglist, pipe_cls, backend)
 
     else:
         raise ValueError('Got unrecognized job backend \'{}\': Expected {}'.format(backend, Backend.options()))
@@ -572,6 +581,7 @@ def add_arg_parser(parsers):
     run_p.add_argument('-ot', '--output-tag', nargs=1, type=str, action='append',
                        help="Output bundle tags: '-ot authoritative:True -ot version:0.7.1'",
                        dest='output_tags')
+    run_p.add_argument("pipeline_root", type=str, help="Root of the Python source tree containing the user-defined transform; must have a setuptools-style setup.py file")
     run_p.add_argument("output_bundle", type=str, help="Name of destination bundle.  '-' means default output bundle.")
     run_p.add_argument("pipe_cls", type=str, help="User-defined transform, e.g., module.PipeClass")
     run_p.add_argument("pipeline_args", type=str,  nargs=argparse.REMAINDER,

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -452,12 +452,16 @@ def _run(
         cli (bool): Whether we called run from the API (buffer output) or the CLI
 
     Returns:
-        job_result (json): A json blob that contains information about the run job.
+        job_result (json): A json blob that contains information about the run job.  Error with empty dict.  If backend
+        is Sagemaker, return TrainingJobArn.   If backend is AWSBatch, return Batch Job description.   If local, return stdout.
     """
 
     pfs = fs.DisdatFS()
 
     pipeline_setup_file = os.path.join(pipeline_root, 'setup.py')
+
+    if not common.setup_exists(pipeline_setup_file):
+        return None
 
     try:
         output_bundle_uuid = pfs.disdat_uuid()

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -38,7 +38,7 @@ import disdat.common as common
 from disdat import logger as _logger
 
 
-def batch_get_job_definition_name(pipeline_class_name):
+def batch_get_job_definition_name(pipeline_image_name):
     """Get the most recent active AWS Batch job definition for a dockerized
     pipeline.
 
@@ -47,9 +47,9 @@ def batch_get_job_definition_name(pipeline_class_name):
     """
 
     try:
-        return '{}-{}-job-definition'.format(getuser(), common.make_pipeline_image_name(pipeline_class_name))
+        return '{}-{}-job-definition'.format(getuser(), pipeline_image_name)
     except Exception as e:
-        return '{}-{}-job-definition'.format('DEFAULT', common.make_pipeline_image_name(pipeline_class_name))
+        return '{}-{}-job-definition'.format('DEFAULT', pipeline_image_name)
 
 
 def batch_get_latest_job_definition(job_definition_name):

--- a/examples/setup.py
+++ b/examples/setup.py
@@ -1,7 +1,7 @@
 from setuptools import find_packages, setup
 
 setup(
-    name='pipelines',
+    name='disdat-example-pipelines',
     version=0.1,
     packages=find_packages(exclude=['config']),
     install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -136,7 +136,9 @@ setup(
     entry_points={
         'console_scripts': [
             'dsdt = disdat.dsdt:main',
+        ],
+        'distutils.commands': [
+            "dsdt_distname = disdat.infrastructure.dockerizer.setup_tools_commands:DistributionName",
         ]
     },
-
 )


### PR DESCRIPTION
1.) create one container per setup.py
2.) support `dsdt dockerize --get-id` to allow external programs to retag
3.) necessitates adding a required param to `dsdt run` to specify the path to the setup.py file. 
