### PR TITLE
bundle_output no longer required in CLI or API

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -489,7 +489,6 @@ class Bundle(HyperFrameRecord):
         target = PipeBase.filename_to_luigi_targets(self.local_dir, file_basename)
 
         with target.temporary_path() as temp_path:
-            print("Trying to copy {} to {}".format(existing_file, temp_path))
             shutil.copyfile(existing_file, temp_path)
 
         return target

--- a/disdat/api.py
+++ b/disdat/api.py
@@ -57,6 +57,9 @@ def _get_fs():
     """ Initializing FS, which needs a config.
     These are both singletons.
 
+    TODO: Do we need the config instance here?  Most calls in fs / dockerize
+    TODO: explicitly ask for an instance anyhow.
+
     Returns:
         `fs.DisdatFS`
 

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -360,8 +360,32 @@ def make_run_command(
         workers,
         pipeline_params
 ):
+    """ Create a list of args.  Note that for execution via run, we always set
+    --output-bundle, even though it is optional.   The CLI and API will place a '-'
+    if the user does not specify it, which means use the default output bundle name.  Here
+    we make sure to pass it through.
+
+    Args:
+        output_bundle:
+        output_bundle_uuid:
+        pipe_cls:
+        remote:
+        context:
+        input_tags:
+        output_tags:
+        force:
+        no_pull:
+        no_push:
+        no_push_int:
+        workers:
+        pipeline_params:
+
+    Returns:
+
+    """
     args = [
         '--output-bundle-uuid ', output_bundle_uuid,
+        '--output-bundle', output_bundle,
         '--remote', remote,
         '--branch', context,
         '--workers', str(workers),
@@ -382,7 +406,6 @@ def make_run_command(
         for next_tag in output_tags:
             args += ['--output-tag', next_tag]
 
-    args += [output_bundle]
     return [x.strip() for x in args + pipeline_params]
 
 

--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -224,17 +224,18 @@ class DataContext(object):
             json_file.write(json.dumps(save_dict))
 
     @staticmethod
-    def load():
+    def load(target_contexts=[]):
         """
         Load the data contexts described at meta_dir.  Each of these is a "remote."
         Args:
-            local_ctxt_dir: Directory of contexts, e.g., ~/.disdat
+            target_contexts (list(str)): If not None, try to load just this context.
 
         Returns:
             (dict) of 'name':context pairs.
 
         """
         ctxt_dir = DisdatConfig.instance().get_context_dir()
+
         if ctxt_dir is None:
             raise Exception("Unable to load context without a metadata directory argument")
 
@@ -243,6 +244,9 @@ class DataContext(object):
         files = glob.glob(os.path.join(ctxt_dir, '*'))
 
         for ctxt in files:
+            if len(target_contexts) > 0 and ctxt not in target_contexts:
+                continue
+
             #_logger.debug("Loading context {}...".format(ctxt))
             meta_file = os.path.join(ctxt_dir, ctxt, META_CTXT_FILE)
 

--- a/disdat/dsdt.py
+++ b/disdat/dsdt.py
@@ -16,7 +16,7 @@
 #
 
 """
-dsdt
+Disdat
 
 Distributed data (dsdt) command line utility for working with data science pipelines.
 
@@ -27,7 +27,7 @@ import logging
 import sys
 import os
 
-from disdat import apply  # @ReservedAssignment
+from disdat import apply
 from disdat import dockerize
 from disdat import run
 from disdat.fs import init_fs_cl
@@ -98,13 +98,14 @@ def main():
                          help="Input bundle tags: '-it authoritative:True -it version:0.7.1'")
     apply_p.add_argument('-ot', '--output-tag', nargs=1, type=str, action='append',
                          help="Output bundle tags: '-ot authoritative:True -ot version:0.7.1'")
-    apply_p.add_argument("output_bundle", type=str, help="Name of destination bundle.  '-' means default output bundle.")
-    apply_p.add_argument("pipe_cls", type=str, help="User-defined transform, e.g., module.PipeClass")
-    apply_p.add_argument("--local", action='store_true', help="Run the class locally (even if dockered)")
-    apply_p.add_argument("--force", action='store_true', help="If there are dependencies, force re-computation.")
-    apply_p.add_argument("--incremental-push", action='store_true', help="Commit and push each task's bundle as it is produced to the remote.")
-    apply_p.add_argument("--incremental-pull", action='store_true', help="Localize bundles as they are needed by downstream tasks from the remote.")
-    apply_p.add_argument("params", type=str,  nargs=argparse.REMAINDER,
+    apply_p.add_argument('-o', '--output-bundle', type=str, default='-',
+                         help="Name output bundle: '-o my.output.bundle'.  Default name is '<TaskName>_<param_hash>'")
+    apply_p.add_argument('--local', action='store_true', help="Run the class locally (even if dockered)")
+    apply_p.add_argument('-f', '--force', action='store_true', help="If there are dependencies, force re-computation.")
+    apply_p.add_argument('--incremental-push', action='store_true', help="Commit and push each task's bundle as it is produced to the remote.")
+    apply_p.add_argument('--incremental-pull', action='store_true', help="Localize bundles as they are needed by downstream tasks from the remote.")
+    apply_p.add_argument('pipe_cls', type=str, help="User-defined transform, e.g., module.PipeClass")
+    apply_p.add_argument('params', type=str,  nargs=argparse.REMAINDER,
                          help="Optional set of parameters for this pipe '--parameter value'")
     apply_p.set_defaults(func=lambda args: _apply(args))
 

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -222,8 +222,8 @@ def run_disdat_container(args):
 
     try:
         result = disdat.api.apply(args.branch,
-                                  args.output_bundle,
                                   args.pipeline,
+                                  output_bundle=args.output_bundle,
                                   input_tags=input_tags,
                                   output_tags=output_tags,
                                   params=pipeline_args,
@@ -357,14 +357,16 @@ def main(input_args):
         help='UUID for the output bundle (default is for apply to generate a UUID)',
     )
     pipeline_parser.add_argument(
+        '-o',
+        '--output-bundle',
+        type=str,
+        default='-',
+        help="Name output bundle: '-o my.output.bundle'.  Default name is '<TaskName>_<param_hash>'"
+    )
+    pipeline_parser.add_argument(
         '--force',
         action='store_true',
         help='Force recomputation of all pipe dependencies (default is to recompute dependencies with changed inputs or code)',
-    )
-    pipeline_parser.add_argument(
-        'output_bundle',
-        type=str,
-        help='Name for the output bundle',
     )
     pipeline_parser.add_argument(
         "pipeline_args",

--- a/disdat/pipe_base.py
+++ b/disdat/pipe_base.py
@@ -18,6 +18,7 @@ import inspect
 import collections
 
 import luigi
+import six
 from six.moves import urllib
 import numpy as np
 import pandas as pd
@@ -392,6 +393,29 @@ class PipeBase(object):
 
         """
 
+        possible_scalar_types = (
+            int,
+            float,
+            str,
+            bool,
+            np.bool_,
+            np.int8,
+            np.int16,
+            np.int32,
+            np.int64,
+            np.uint8,
+            np.uint16,
+            np.uint32,
+            np.uint64,
+            np.float16,
+            np.float32,
+            np.float64,
+            six.binary_type,
+            six.text_type,
+            np.unicode_,
+            np.string_
+        )
+
         frames = []
 
         managed_path = os.path.join(data_context.get_object_dir(), hfid)
@@ -418,6 +442,8 @@ class PipeBase(object):
             presentation = hyperframe_pb2.ROW
             for k, v in val.items():
                 if not isinstance(v, (list, tuple, pd.core.series.Series, np.ndarray, collections.Sequence)):
+                    # assuming this is a scalar
+                    assert isinstance(v, possible_scalar_types), 'Disdat requires dictionary values to be one of {} not {}'.format(possible_scalar_types, type(v))
                     frames.append(DataContext.convert_scalar2frame(hfid, k, v, managed_path))
                 else:
                     assert isinstance(v, (list, tuple, pd.core.series.Series, np.ndarray, collections.Sequence))

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -525,6 +525,7 @@ def add_arg_parser(parsers):
         help='An optional batch execution back-end to use',
     )
     run_p.add_argument(
+        "-f",
         "--force",
         action='store_true',
         help="If there are dependencies, force re-computation."
@@ -587,8 +588,9 @@ def add_arg_parser(parsers):
     run_p.add_argument('-ot', '--output-tag', nargs=1, type=str, action='append',
                        help="Output bundle tags: '-ot authoritative:True -ot version:0.7.1'",
                        dest='output_tags')
+    run_p.add_argument('-o', '--output-bundle', type=str, default='-',
+                       help="Name output bundle: '-o my.output.bundle'.  Default name is '<TaskName>_<param_hash>'")
     run_p.add_argument("pipeline_root", type=str, help="Root of the Python source tree containing the user-defined transform; must have a setuptools-style setup.py file")
-    run_p.add_argument("output_bundle", type=str, help="Name of destination bundle.  '-' means default output bundle.")
     run_p.add_argument("pipe_cls", type=str, help="User-defined transform, e.g., module.PipeClass")
     run_p.add_argument("pipeline_args", type=str,  nargs=argparse.REMAINDER,
                        help="Optional set of parameters for this pipe '--parameter value'")

--- a/examples/pipelines/demo_pipeline.py
+++ b/examples/pipelines/demo_pipeline.py
@@ -68,4 +68,4 @@ class Average(PipeTask):
 
 
 if __name__ == "__main__":
-    api.apply('examples', '-', 'Average', params={})
+    api.apply('examples', 'Average', params={})

--- a/examples/pipelines/df_dup.py
+++ b/examples/pipelines/df_dup.py
@@ -74,4 +74,4 @@ class DFDup(PipeTask):
 
 
 if __name__ == "__main__":
-    api.apply('examples', '-', 'DFDup', params={})
+    api.apply('examples', 'DFDup', params={})

--- a/examples/pipelines/download.py
+++ b/examples/pipelines/download.py
@@ -112,4 +112,4 @@ class Download(pipe.PipeTask):
 
 
 if __name__ == "__main__":
-    api.apply('examples', '-', 'Download', params={'input_url': './download.py'})
+    api.apply('examples', 'Download', params={'input_url': './download.py'})

--- a/examples/pipelines/files.py
+++ b/examples/pipelines/files.py
@@ -125,4 +125,4 @@ class ReadFiles(PipeTask):
 
 
 if __name__ == "__main__":
-    api.apply('examples', '-', 'ReadFiles', params={'num_luigi_files':5})
+    api.apply('examples', 'ReadFiles', params={'num_luigi_files':5})

--- a/examples/pipelines/mnist.py
+++ b/examples/pipelines/mnist.py
@@ -257,4 +257,4 @@ class Evaluate(PipeTask):
 
 if __name__ == "__main__":
     print ("Using Disdat API to run the pipeline")
-    api.apply('examples', '-', 'Evaluate')
+    api.apply('examples', 'Evaluate')

--- a/examples/pipelines/nlp_spacy.py
+++ b/examples/pipelines/nlp_spacy.py
@@ -74,4 +74,4 @@ class SimpleNLP(PipeTask):
 
 
 if __name__ == "__main__":
-    api.apply('examples', 'SimpleNLP.example.output', 'SimpleNLP')
+    api.apply('examples', 'SimpleNLP')

--- a/examples/pipelines/simple_tree.py
+++ b/examples/pipelines/simple_tree.py
@@ -18,7 +18,7 @@ from disdat.pipe import PipeTask
 import disdat.api as api
 import luigi
 import logging
-from tree_leaves import B
+from pipelines.tree_leaves import B
 
 """
 SimpleTree
@@ -88,4 +88,4 @@ class SimpleTree(PipeTask):
 
 
 if __name__ == "__main__":
-    api.apply('examples', 'SimpleTree.example.output', 'SimpleTree')
+    api.apply('examples', 'SimpleTree')

--- a/examples/setup.py
+++ b/examples/setup.py
@@ -7,8 +7,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'luigi',
-        #'spacy',
+        'spacy',
         'pandas==0.20.3',
-        #'tensorflow',
+        'tensorflow',
     ],
 )

--- a/examples/setup.py
+++ b/examples/setup.py
@@ -7,8 +7,8 @@ setup(
     include_package_data=True,
     install_requires=[
         'luigi',
-        'spacy',
+        #'spacy',
         'pandas==0.20.3',
-        'tensorflow',
+        #'tensorflow',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -116,6 +116,10 @@ setup(
     # for example:
     # $ pip install -e '.[dev, rel]'
     extras_require={
+        'examples': [
+            'spacy',
+            'tensorflow',
+        ],
         'dev': [
             'pytest',
             'ipython<6.0',

--- a/tests/functional/test_api_exit.py
+++ b/tests/functional/test_api_exit.py
@@ -41,7 +41,7 @@ def test():
 
     result = None
     try:
-        result = api.apply(TEST_CONTEXT, 'test_api_exit', 'Root2', params={}, force=True, workers=2)
+        result = api.apply(TEST_CONTEXT, 'Root2', output_bundle='test_api_exit', params={}, force=True, workers=2)
     except Exception as e:
         print ("Got exception {} result {} ".format(e, e.result))
         assert(e.result['did_work'])

--- a/tests/functional/test_context.py
+++ b/tests/functional/test_context.py
@@ -43,7 +43,7 @@ def test_independent_context():
     api.context(context_1_name)
     api.context(context_2_name)
 
-    api.apply(context_1_name, '-', 'ContextTest')
+    api.apply(context_1_name, 'ContextTest')
 
     assert len(api.search(context_1_name)) == 1, 'Only one bundle should be in context one'
     assert len(api.search(context_2_name)) == 0, 'Context two should be empty'

--- a/tests/functional/test_external_bundle.py
+++ b/tests/functional/test_external_bundle.py
@@ -41,7 +41,7 @@ def test():
 
     api.context(TEST_CONTEXT)
 
-    api.apply(TEST_CONTEXT, '-', 'DataMaker', params={'int_array': '[1000,2000,3000]'})
+    api.apply(TEST_CONTEXT, 'DataMaker', params={'int_array': '[1000,2000,3000]'})
 
     b = api.get(TEST_CONTEXT, 'PreMaker_auf_datamaker')
 
@@ -49,7 +49,7 @@ def test():
 
     b.rm()
 
-    api.apply(TEST_CONTEXT, '-', 'Root_1')
+    api.apply(TEST_CONTEXT, 'Root_1')
 
     b = api.get(TEST_CONTEXT, 'PreMaker_auf_root')
 

--- a/tests/functional/test_mark_force.py
+++ b/tests/functional/test_mark_force.py
@@ -29,7 +29,7 @@ def test():
     """
 
     def run_and_get(name, do_ext=False):
-        api.apply(TEST_CONTEXT, '-', 'A_2', params={'set_ext_dep': do_ext})
+        api.apply(TEST_CONTEXT, 'A_2', params={'set_ext_dep': do_ext})
         b = api.get(TEST_CONTEXT, 'B')
         print ("Run {}: b.creation_date {} b.uuid {}".format(name, b.creation_date, b.uuid))
         return b

--- a/tests/functional/test_output_types.py
+++ b/tests/functional/test_output_types.py
@@ -50,7 +50,7 @@ class IntTask(PipeTask):
 def test_int_task():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'IntTask')
+    api.apply(TEST_CONTEXT, 'IntTask')
     data = api.get(TEST_CONTEXT, 'int_task').data
 
     assert data == 1, 'Data did not match output'
@@ -69,7 +69,7 @@ class StringTask(PipeTask):
 def test_string_task():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'StringTask')
+    api.apply(TEST_CONTEXT, 'StringTask')
     data = api.get(TEST_CONTEXT, 'string_task').data
 
     assert data == 'output', 'Data did not match output'
@@ -88,7 +88,7 @@ class FloatTask(PipeTask):
 def test_float_task():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'FloatTask')
+    api.apply(TEST_CONTEXT, 'FloatTask')
     data = api.get(TEST_CONTEXT, 'float_task').data
 
     assert data == 2.5, 'Data did not match output'
@@ -107,7 +107,7 @@ class ListTask(PipeTask):
 def test_list_task():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'ListTask')
+    api.apply(TEST_CONTEXT, 'ListTask')
     data = api.get(TEST_CONTEXT, 'list_task').data
 
     assert np.array_equal(data, [1, 2, 3]), 'Data did not match output'
@@ -128,7 +128,7 @@ class DataFrameTask(PipeTask):
 def test_df_task():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'DataFrameTask')
+    api.apply(TEST_CONTEXT, 'DataFrameTask')
     data = api.get(TEST_CONTEXT, 'df_task').data
 
     df = pd.DataFrame()
@@ -154,7 +154,7 @@ class FileTask(PipeTask):
 def test_file_task():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'FileTask')
+    api.apply(TEST_CONTEXT, 'FileTask')
     output_path = api.get(TEST_CONTEXT, 'file_task').data
 
     with open(output_path) as f:
@@ -164,29 +164,29 @@ def test_file_task():
     assert type(output_path )== str, 'Data is not path'
     assert len(api.search(TEST_CONTEXT)) == 1, 'Only one bundle should be present'
 
-# Does not support dict return type
-# class DictTask(PipeTask):
-#     def pipe_requires(self, pipeline_input=None):
-#         self.set_bundle_name('dict_task')
-#
-#     def pipe_run(self, pipeline_input=None):
-#         return {
-#             'hello': 'world'
-#         }
-#
-#
-# def test_dict_task():
-#     setup()
-#     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
-#
-#     api.apply(TEST_CONTEXT, '-', '-', 'DictTask')
-#     data = api.get(TEST_CONTEXT, 'dict_task').data
-#
-#     assert data == {
-#         'hello': 'world'
-#     }, 'Data did not match output'
-#     assert type(data) == dict, 'Data is not dict'
-#     assert len(api.search(TEST_CONTEXT)) == 1, 'Only one bundle should be present'
+
+class DictTask(PipeTask):
+    def pipe_requires(self, pipeline_input=None):
+        self.set_bundle_name('dict_task')
+
+    def pipe_run(self, pipeline_input=None):
+        return {
+            'hello': ['world']
+        }
+
+
+def test_dict_task():
+    setup()
+    assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
+
+    api.apply(TEST_CONTEXT, 'DictTask')
+    data = api.get(TEST_CONTEXT, 'dict_task').data
+
+    assert data == {
+    'hello': ['world']
+    }, 'Data did not match output'
+    assert type(data) == dict, 'Data is not dict'
+    assert len(api.search(TEST_CONTEXT)) == 1, 'Only one bundle should be present'
 
 
 if __name__ == '__main__':

--- a/tests/functional/test_pipeline.py
+++ b/tests/functional/test_pipeline.py
@@ -56,21 +56,21 @@ class C(PipeTask):
 def test_single_task():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'A')
+    api.apply(TEST_CONTEXT, 'A')
     data = api.get(TEST_CONTEXT, 'a').data
 
     assert data == 2, 'Data did not match output'
     assert type(data) == int, 'Data is not path'
     assert len(api.search(TEST_CONTEXT)) == 1, 'Only one bundle should be present'
 
-    api.apply(TEST_CONTEXT, '-', 'A')
+    api.apply(TEST_CONTEXT, 'A')
     assert len(api.search(TEST_CONTEXT)) == 1, 'Only one bundle should be present'
 
 
 def test_dependant_tasks():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'C')
+    api.apply(TEST_CONTEXT,  'C')
     data = api.get(TEST_CONTEXT, 'c').data
 
     assert data == 6, 'Data did not match output'
@@ -81,14 +81,14 @@ def test_dependant_tasks():
 def test_task_with_parameter():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'B', params={'n': 10})
+    api.apply(TEST_CONTEXT,  'B', params={'n': 10})
     data = api.get(TEST_CONTEXT, 'b').data
 
     assert data == 20, 'Data did not match output'
     assert type(data) == int, 'Data is not path'
     assert len(api.search(TEST_CONTEXT)) == 1, 'One bundle should be present'
 
-    api.apply(TEST_CONTEXT, '-', 'B', params={'n': 20})
+    api.apply(TEST_CONTEXT,  'B', params={'n': 20})
     data = api.get(TEST_CONTEXT, 'b').data
 
     assert data == 40, 'Data did not match output'
@@ -99,14 +99,14 @@ def test_task_with_parameter():
 def test_child_task_with_parameter():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
 
-    api.apply(TEST_CONTEXT, '-', 'C', params={'n': 10})
+    api.apply(TEST_CONTEXT,  'C', params={'n': 10})
     data = api.get(TEST_CONTEXT, 'c').data
 
     assert data == 22, 'Data did not match output'
     assert type(data) == int, 'Data is not path'
     assert len(api.search(TEST_CONTEXT)) == 3, 'Three bundles should be present'
 
-    api.apply(TEST_CONTEXT, '-', 'C', params={'n': 20})
+    api.apply(TEST_CONTEXT,  'C', params={'n': 20})
     data = api.get(TEST_CONTEXT, 'c').data
 
     assert data == 42, 'Data did not match output'

--- a/tests/functional/test_remote.py
+++ b/tests/functional/test_remote.py
@@ -49,7 +49,7 @@ def test_push():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
     api.remote(TEST_CONTEXT, TEST_REMOTE, TEST_BUCKET_URL, force=True)
 
-    api.apply(TEST_CONTEXT, '-', 'RemoteTest')
+    api.apply(TEST_CONTEXT,  'RemoteTest')
     bundle = api.get(TEST_CONTEXT, 'remote_test')
 
     assert bundle.data == 'Hello'
@@ -81,7 +81,7 @@ def test_pull():
     assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
     api.remote(TEST_CONTEXT, TEST_REMOTE, TEST_BUCKET_URL, force=True)
 
-    api.apply(TEST_CONTEXT, '-', 'RemoteTest')
+    api.apply(TEST_CONTEXT,  'RemoteTest')
     bundle = api.get(TEST_CONTEXT, 'remote_test')
 
     assert bundle.data == 'Hello'

--- a/tests/functional/test_requires.py
+++ b/tests/functional/test_requires.py
@@ -38,5 +38,5 @@ class a(Bizarre):
 
 class b(Bizarre):
     def pipe_requires(self):
-        self.add_dependency('something',a,{})
+        self.add_dependency('something', a, {})
 


### PR DESCRIPTION
1.) API and CLI apply and run no longer require bundle_output argument
2.) Updated API comments throughout
3.) Updated API to create fs and config objects per call 
4.) Updated fs to have a reload_context and reload_all_contexts calls.  Contexts can change via the CLI when using the API (as in a notebook), so some calls, like ls_context(), should re-read disk to see if new contexts appear (or deleted ones go away).