### PR TITLE
Update entrypoint.py required arg to positional

### DIFF
--- a/disdat/common.py
+++ b/disdat/common.py
@@ -388,8 +388,7 @@ def make_run_command(
         '--output-bundle', output_bundle,
         '--remote', remote,
         '--branch', context,
-        '--workers', str(workers),
-        '--pipeline', str(pipe_cls)
+        '--workers', str(workers)
     ]
     if no_pull:
         args += ['--no-pull']
@@ -405,6 +404,8 @@ def make_run_command(
     if len(output_tags) > 0:
         for next_tag in output_tags:
             args += ['--output-tag', next_tag]
+
+    args += [str(pipe_cls)]  # The one required argument to the entrypoint
 
     return [x.strip() for x in args + pipeline_params]
 

--- a/disdat/dsdt.py
+++ b/disdat/dsdt.py
@@ -104,7 +104,7 @@ def main():
     apply_p.add_argument('-f', '--force', action='store_true', help="If there are dependencies, force re-computation.")
     apply_p.add_argument('--incremental-push', action='store_true', help="Commit and push each task's bundle as it is produced to the remote.")
     apply_p.add_argument('--incremental-pull', action='store_true', help="Localize bundles as they are needed by downstream tasks from the remote.")
-    apply_p.add_argument('pipe_cls', type=str, help="User-defined transform, e.g., module.PipeClass")
+    apply_p.add_argument('pipe_cls', type=str, help="User-defined transform, e.g., 'module.PipeClass'")
     apply_p.add_argument('params', type=str,  nargs=argparse.REMAINDER,
                          help="Optional set of parameters for this pipe '--parameter value'")
     apply_p.set_defaults(func=lambda args: _apply(args))

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -313,13 +313,6 @@ def main(input_args):
     )
 
     pipeline_parser = parser.add_argument_group('pipe arguments')
-    pipeline_parser.add_argument(
-        '--pipeline',
-        default=None,
-        type=str,
-        required=True,
-        help=add_argument_help_string('Name of the pipeline class to run'),
-    )
 
     pipeline_parser.add_argument(
         '--branch',
@@ -356,6 +349,7 @@ def main(input_args):
         type=str,
         help='UUID for the output bundle (default is for apply to generate a UUID)',
     )
+
     pipeline_parser.add_argument(
         '-o',
         '--output-bundle',
@@ -363,11 +357,20 @@ def main(input_args):
         default='-',
         help="Name output bundle: '-o my.output.bundle'.  Default name is '<TaskName>_<param_hash>'"
     )
+
     pipeline_parser.add_argument(
         '--force',
         action='store_true',
         help='Force recomputation of all pipe dependencies (default is to recompute dependencies with changed inputs or code)',
     )
+
+    pipeline_parser.add_argument(
+        'pipeline',
+        default=None,
+        type=str,
+        help=add_argument_help_string("Name of the pipeline class to run, e.g., 'package.module.ClassName'"),
+    )
+
     pipeline_parser.add_argument(
         "pipeline_args",
         nargs=argparse.REMAINDER,

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -69,14 +69,13 @@ class Backend(Enum):
         return [i.name for i in list(Backend)]
 
 
-def _run_local(cli, pipeline_setup_file, arglist, pipeline_class_name, backend):
+def _run_local(cli, pipeline_setup_file, arglist, backend):
     """
     Run container locally or run sagemaker container locally
     Args:
         cli (bool): Whether we were called from the CLI or API
         pipeline_setup_file (str): The FQ path to the setup.py used to dockerize the pipeline.
         arglist:
-        pipeline_class_name:
         backend:
 
     Returns:
@@ -315,7 +314,7 @@ def _sagemaker_hyperparameters_from_arglist(arglist):
     return {'arglist': json.dumps(arglist)}
 
 
-def _run_aws_sagemaker(arglist, fq_repository_name, job_name, pipeline_class_name):
+def _run_aws_sagemaker(arglist, fq_repository_name, job_name):
     """
     Runs a training job on AWS SageMaker.  This uses the default machine type
     in the disdat.cfg file.
@@ -324,7 +323,6 @@ def _run_aws_sagemaker(arglist, fq_repository_name, job_name, pipeline_class_nam
         arglist:
         fq_repository_name (str): fully qualified repository name
         job_name:  instance job name
-        pipeline_class_name: The package.module.class Disdat task we are executing.
 
     Returns:
         TrainingJobArn (str)
@@ -503,11 +501,10 @@ def _run(
 
             retval = _run_aws_sagemaker(arglist,
                                         fq_repository_name,
-                                        job_name,
-                                        pipe_cls)
+                                        job_name)
 
     elif backend == Backend.Local or backend == Backend.LocalSageMaker:
-        retval = _run_local(cli, pipeline_setup_file, arglist, pipe_cls, backend)
+        retval = _run_local(cli, pipeline_setup_file, arglist, backend)
 
     else:
         raise ValueError('Got unrecognized job backend \'{}\': Expected {}'.format(backend, Backend.options()))


### PR DESCRIPTION
Problem:  There were no positional parameters, which means the arg parser could not distinguish between args for the entrypoint and remainder args for the pipeline
Solution: Move the one required argument to a positional argument. 