### PR TITLE
Add failure conditions to git hash extraction 

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -286,9 +286,12 @@ class Bundle(HyperFrameRecord):
             self.pb.presentation = presentation
 
             # TODO: we should let user decide which file under git or explicitly set hash
-            # This is simply a placeholder.   
-            pipeline_path = os.path.dirname(sys.modules[BundleWrapperTask.__module__].__file__)
-            cv = DisdatFS().get_pipe_version(pipeline_path)
+            if False:
+                pipeline_path = os.path.dirname(sys.modules[BundleWrapperTask.__module__].__file__)
+                cv = DisdatFS().get_pipe_version(pipeline_path)
+            else:
+                cv = disdat.fs.CodeVersion(semver="0.1.0", hash="unknown", tstamp="unknown", branch="unknown",
+                                      url="unknown", dirty="unknown")
 
             lr = LineageRecord(hframe_name=self._set_processing_name(), # <--- setting processing name
                                hframe_uuid=self.uuid,

--- a/disdat/api.py
+++ b/disdat/api.py
@@ -285,6 +285,8 @@ class Bundle(HyperFrameRecord):
 
             self.pb.presentation = presentation
 
+            # TODO: we should let user decide which file under git or explicitly set hash
+            # This is simply a placeholder.   
             pipeline_path = os.path.dirname(sys.modules[BundleWrapperTask.__module__].__file__)
             cv = DisdatFS().get_pipe_version(pipeline_path)
 

--- a/disdat/config/disdat/disdat.cfg
+++ b/disdat/config/disdat/disdat.cfg
@@ -20,10 +20,13 @@ ignore_code_version=True
 
 [dockerize]
 os_type = python
-os_version = 2.7.15-slim
+os_version = 3.6.8-slim
+
+# Optional other value for os_version
+# os_version = 2.7.15-slim
 
 # Optional pip file
-#dot_pip_file = ~/.pip/pip.conf
+# dot_pip_file = ~/.pip/pip.conf
 
 # Optional odbc file bake-in.
 

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -100,16 +100,31 @@ def determine_pipe_version(pipe_root):
         which haven't been checked in yet.
     """
 
+    def _check_type_and_rstrip(val, default):
+        if isinstance(val, six.string_types):
+            val = val.rstrip()
+        else:
+            val = default
+        return val
+
     _logger.debug("PIPELINE_GIT_HASH = {}  cli hash = {}".format(os.environ.get('PIPELINE_GIT_HASH'),
                                                                  _run_git_cmd(pipe_root, 'rev-parse --short HEAD', get_output=True)))
     _logger.debug("git_branch = {os.environ.get('PIPELINE_GIT_BRANCH')}")
 
-    git_hash = os.getenv('PIPELINE_GIT_HASH', _run_git_cmd(pipe_root, 'rev-parse HEAD',  get_output=True)).rstrip()
-    git_branch = os.getenv('PIPELINE_GIT_BRANCH', _run_git_cmd(pipe_root, 'rev-parse --abbrev-ref HEAD',  get_output=True)).rstrip()
-    git_fetch_url = os.getenv('PIPELINE_GIT_FETCH_URL', _run_git_cmd(pipe_root, 'config --get remote.origin.url',  get_output=True)).rstrip()
-    git_timestamp = os.getenv('PIPELINE_GIT_TIMESTAMP', _run_git_cmd(pipe_root, 'log -1 --pretty=format:%aI',  get_output=True)).rstrip()
+    git_hash = os.getenv('PIPELINE_GIT_HASH', _run_git_cmd(pipe_root, 'rev-parse HEAD',  get_output=True))
+    git_hash = _check_type_and_rstrip(git_hash, "unknown")
+
+    git_branch = os.getenv('PIPELINE_GIT_BRANCH', _run_git_cmd(pipe_root, 'rev-parse --abbrev-ref HEAD',  get_output=True))
+    git_branch = _check_type_and_rstrip(git_branch, "unknown")
+
+    git_fetch_url = os.getenv('PIPELINE_GIT_FETCH_URL', _run_git_cmd(pipe_root, 'config --get remote.origin.url',  get_output=True))
+    git_fetch_url = _check_type_and_rstrip(git_fetch_url, "unknown")
+
+    git_timestamp = os.getenv('PIPELINE_GIT_TIMESTAMP', _run_git_cmd(pipe_root, 'log -1 --pretty=format:%aI',  get_output=True))
+    git_timestamp = _check_type_and_rstrip(git_timestamp, "unknown")
+
     git_dirty = bool(os.getenv('GIT_DIRTY', _run_git_cmd(pipe_root, 'diff --name-only',  get_output=True)))
-    
+
     obj_version = CodeVersion(semver="0.1.0", hash=git_hash, tstamp=git_timestamp, branch=git_branch,
                               url=git_fetch_url, dirty=git_dirty)
 

--- a/disdat/lineage.py
+++ b/disdat/lineage.py
@@ -46,11 +46,13 @@ def print_lineage_protobuf(lineage_pb, offset=0):
 
     print("{}Start {} Stop {} Duration {}".format(indent, lineage_pb.start_time, lineage_pb.stop_time, duration))
 
-    user, site = lineage_pb.code_repo.split('@')
-    site, project_url = site.split(':')
-    project_url = project_url.replace('.git', '')
-
-    url = "https://{}/{}/commit/{}".format(site, project_url, lineage_pb.code_hash)
+    try:
+        user, site = lineage_pb.code_repo.split('@')
+        site, project_url = site.split(':')
+        project_url = project_url.replace('.git', '')
+        url = "https://{}/{}/commit/{}".format(site, project_url, lineage_pb.code_hash)
+    except Exception as e:
+        url = "unknown"
 
     print("{}git commit URL: {}".format(indent,url))
     print("{}code branch: {}".format(indent,lineage_pb.code_branch))

--- a/disdat/lineage.py
+++ b/disdat/lineage.py
@@ -41,25 +41,32 @@ def print_lineage_protobuf(lineage_pb, offset=0):
     print("{}processing name: {}".format(indent, lineage_pb.hframe_name))
     print("{}uuid: {}".format(indent, lineage_pb.hframe_uuid))
     print("{}creation date: {}".format(indent, datetime.fromtimestamp(lineage_pb.creation_date)))
-
-    duration = lineage_pb.stop_time - lineage_pb.start_time
-
-    print("{}Start {} Stop {} Duration {}".format(indent, lineage_pb.start_time, lineage_pb.stop_time, duration))
+    print("{}code repo: {}".format(indent, lineage_pb.code_repo))
+    print("{}code hash: {}".format(indent, lineage_pb.code_hash))
 
     try:
-        user, site = lineage_pb.code_repo.split('@')
-        site, project_url = site.split(':')
-        project_url = project_url.replace('.git', '')
-        url = "https://{}/{}/commit/{}".format(site, project_url, lineage_pb.code_hash)
+        repo = lineage_pb.code_repo.split('@')
+        if len(repo) == 2:
+            # Assume: git@github.intuit.com:user/project.git
+            _ , site = repo
+            site, project_url = site.split(':')
+            project_url = project_url.replace('.git', '')
+            url = "https://{}/{}/commit/{}".format(site, project_url, lineage_pb.code_hash)
+        else:
+            # Assume:  https://github.com/user/project.git
+            assert len(repo) == 1
+            project_url = repo[0].replace('.git', '')
+            url = "{}/commit/{}".format(project_url, lineage_pb.code_hash)
     except Exception as e:
+        print (e)
         url = "unknown"
 
     print("{}git commit URL: {}".format(indent,url))
     print("{}code branch: {}".format(indent,lineage_pb.code_branch))
 
-    # XXX Currently these aren't set appropriately
-    # print("code name: {}".format(lineage_pb.code_name))
-    # print("code semver: {}".format(lineage_pb.code_semver))
+    duration = lineage_pb.stop_time - lineage_pb.start_time
+
+    print("{}Start {} Stop {} Duration {}".format(indent, lineage_pb.start_time, lineage_pb.stop_time, duration))
 
 
 def _lineage(**kwargs):

--- a/tests/functional/test_add.py
+++ b/tests/functional/test_add.py
@@ -314,3 +314,8 @@ def test_data_as_bundle_not_csv(tmpdir):
     assert api.get(TEST_CONTEXT, 'test_file_as_bundle_txt_file') is None, 'Bundle should not exist'
 
     api.delete_context(TEST_CONTEXT)
+
+
+if __name__ == '__main__':
+    import tempfile
+    test_single_file(tempfile.gettempdir())


### PR DESCRIPTION
Issue: When adding a bundle using `api.add`, we were using a disdat file to get the git hash.  This won't work when installed as an sdist (since there will be no git repo).   

Resolution: Add return value checks on the external git commands.     