### PR TITLE
removed boto session cache dependency from `dsdt run` 

### DIFF
--- a/disdat/run.py
+++ b/disdat/run.py
@@ -281,9 +281,8 @@ def _run_aws_batch(arglist, fq_repository_name, job_name, pipeline_image_name,
                 {'name': 'AWS_SESSION_TOKEN', 'value': credentials['SessionToken']}
             ]
         except Exception as e:
-            print ("Failed to get a token, trying users default credentials...")
-            credentials = b3.session().get_credentials()
-            #print (credentials.__dict__)
+            _logger.debug("Unable to generate an STS token, instead trying users default credentials...")
+            credentials = b3.session.Session().get_credentials()
             container_overrides['environment'] = [
                 {'name': 'AWS_ACCESS_KEY_ID', 'value': credentials.access_key},
                 {'name': 'AWS_SECRET_ACCESS_KEY', 'value': credentials.secret_key},


### PR DESCRIPTION
We try to generate a temporary token using STS to submit the batch job.   But if the user already has temporary credentials we use those instead.   But that code hadn't been updated to just using boto.  Now it is. 