### PR TITLE
Dockerize fixes

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -108,8 +108,8 @@ class BundleWrapperTask(PipeTask):
     Note:  No processing_name and No UUID
     """
     name = luigi.Parameter(default=None)
-    owner = luigi.Parameter(default=None)
-    tags = luigi.DictParameter(default={})
+    owner = luigi.Parameter(default=None, significant=False)
+    tags = luigi.DictParameter(default={}, significant=False)
 
     def bundle_inputs(self):
         """ Determine input bundles """
@@ -680,7 +680,7 @@ def search(local_context, search_name=None, search_tags=None,
         is_committed (bool): If None (default): ignore committed, If True return committed, If False return uncommitted
         find_intermediates (bool):  Results must be intermediates
         find_roots (bool): Results must be final outputs
-        before (str): Return bundles <= "12-1-2009" or "12-1-2009 12:13:42"
+        before (str): Return bundles < "12-1-2009" or "12-1-2009 12:13:42"
         after (str): Return bundles >= "12-1-2009" or "12-1-2009 12:13:42"
 
     Returns:
@@ -878,7 +878,6 @@ def add(local_context, bundle_name, path, tags=None, treat_file_as_bundle=False)
     assert os.path.exists(path), "Disdat cannot find file at path: {}".format(path)
 
     with Bundle(local_context, bundle_name, getpass.getuser()) as b:
-
         if treat_file_as_bundle:
             # Make sure file is .csv or .tsv
             assert str(path).endswith(('.csv', '.tsv')), 'Disdat can only add tsv/csv files as bundles, please ' \
@@ -912,7 +911,8 @@ def add(local_context, bundle_name, path, tags=None, treat_file_as_bundle=False)
 
         if tags is not None and len(tags) > 0:
             b.add_tags(tags)
-        return b
+
+    return b
 
 
 def cat(local_context, bundle_name):

--- a/disdat/dockerize.py
+++ b/disdat/dockerize.py
@@ -183,7 +183,7 @@ def dockerize(pipeline_root,
             'make',  # XXX really need to check that this is GNU make
             '-f', docker_makefile,
             'PIPELINE_IMAGE_NAME={}'.format(pipeline_image_name),
-            'DOCKER_CONTEXT={}'.format(docker_context),
+            'DISDAT_DOCKER_CONTEXT={}'.format(docker_context),
             'DISDAT_ROOT={}'.format(os.path.join(DISDAT_HOME)),  # XXX YUCK
             'PIPELINE_ROOT={}'.format(pipeline_root),
             'OS_TYPE={}'.format(image_os_type),

--- a/disdat/infrastructure/dockerizer/Makefile
+++ b/disdat/infrastructure/dockerizer/Makefile
@@ -9,9 +9,9 @@ $(error PIPELINE_IMAGE_NAME variable not set)
 endif
 
 # The root for the Docker context in which we will build the image
-DOCKER_CONTEXT := $(shell echo $(DOCKER_CONTEXT) | sed 's/\/*$$//')
-ifeq ($(DOCKER_CONTEXT), )
-$(error DOCKER_CONTEXT variable not set or invalid)
+DISDAT_DOCKER_CONTEXT := $(shell echo $(DISDAT_DOCKER_CONTEXT) | sed 's/\/*$$//')
+ifeq ($(DISDAT_DOCKER_CONTEXT), )
+$(error DISDAT_DOCKER_CONTEXT variable not set or invalid)
 endif
 
 # The root of the Disdat source distribution
@@ -33,10 +33,10 @@ endif
 
 # The root of the Docker context template (Dockerfiles, kickstart scripts,
 # etc.)
-DOCKER_CONTEXT_TEMPLATE ?= $(DISDAT_ROOT)/disdat/infrastructure/dockerizer/context.template
-DOCKER_CONTEXT_TEMPLATE := $(shell echo $(DOCKER_CONTEXT_TEMPLATE) | sed 's/\/*$$//')
-ifeq ($(DOCKER_CONTEXT_TEMPLATE), )
-$(error DOCKER_CONTEXT_TEMPLATE variable not set or invalid)
+DISDAT_DOCKER_CONTEXT_TEMPLATE ?= $(DISDAT_ROOT)/disdat/infrastructure/dockerizer/context.template
+DISDAT_DOCKER_CONTEXT_TEMPLATE := $(shell echo $(DISDAT_DOCKER_CONTEXT_TEMPLATE) | sed 's/\/*$$//')
+ifeq ($(DISDAT_DOCKER_CONTEXT_TEMPLATE), )
+$(error DISDAT_DOCKER_CONTEXT_TEMPLATE variable not set or invalid)
 endif
 
 # The source root of the pipeline to run
@@ -106,33 +106,33 @@ all: build
 #           and scripts/executables
 #
 
-build: $(DOCKER_CONTEXT) build-00 build-01 build-02
+build: $(DISDAT_DOCKER_CONTEXT) build-00 build-01 build-02
 	@echo "----- Built Docker image for the $(PIPELINE_IMAGE_NAME) pipeline on $(OS_NAME)"
 
 sagemaker: build build-03
 	@echo "----- Built SageMaker Docker image for the $(PIPELINE_IMAGE_NAME) pipeline on $(OS_NAME)"
 
-build-00: $(DOCKER_CONTEXT)
+build-00: $(DISDAT_DOCKER_CONTEXT)
 	@echo "---------- Building base operating system environment"
 	docker build \
 		--build-arg KICKSTART_ROOT=$(IMAGE_KICKSTART_ROOT) \
 		--build-arg CONDA_VERSION=$(IMAGE_CONDA_VERSION) \
 		--build-arg VIRTUAL_ENV=$(IMAGE_VIRTUAL_ENV) \
-		--file $(DOCKER_CONTEXT)/Dockerfiles/00-disdat-$(OS_NAME).dockerfile \
+		--file $(DISDAT_DOCKER_CONTEXT)/Dockerfiles/00-disdat-$(OS_NAME).dockerfile \
 		--tag $(IMAGE_00_LAYER) \
-		$(DOCKER_CONTEXT)
+		$(DISDAT_DOCKER_CONTEXT)
 
-build-01: $(DOCKER_CONTEXT) $(DOCKER_CONTEXT)/disdat
+build-01: $(DISDAT_DOCKER_CONTEXT) $(DISDAT_DOCKER_CONTEXT)/disdat
 	@echo "---------- Building Disdat and its Python package dependencies"
 	docker build \
 		--build-arg IMAGE_LAYER=$(IMAGE_00_LAYER) \
 		--build-arg BUILD_ROOT=$(IMAGE_BUILD_ROOT) \
 		--build-arg DISDAT_SDIST=$(DISDAT_SDIST) \
-		--file $(DOCKER_CONTEXT)/Dockerfiles/01-disdat-python.dockerfile  \
+		--file $(DISDAT_DOCKER_CONTEXT)/Dockerfiles/01-disdat-python.dockerfile  \
 		--tag $(IMAGE_01_LAYER) \
-		$(DOCKER_CONTEXT)
+		$(DISDAT_DOCKER_CONTEXT)
 
-build-02: $(DOCKER_CONTEXT) $(DOCKER_CONTEXT)/config $(DOCKER_CONTEXT)/pipeline
+build-02: $(DISDAT_DOCKER_CONTEXT) $(DISDAT_DOCKER_CONTEXT)/config $(DISDAT_DOCKER_CONTEXT)/pipeline
 	@echo "---------- Installing the user environment"
 	docker build \
 		--build-arg OS_NAME=$(OS_NAME) \
@@ -143,40 +143,40 @@ build-02: $(DOCKER_CONTEXT) $(DOCKER_CONTEXT)/config $(DOCKER_CONTEXT)/pipeline
 		--build-arg GIT_FETCH_URL=$(GIT_FETCH_URL) \
 		--build-arg GIT_TIMESTAMP=$(GIT_TIMESTAMP) \
 		--build-arg GIT_DIRTY=$(GIT_DIRTY) \
-		--file $(DOCKER_CONTEXT)/Dockerfiles/02-user.dockerfile \
+		--file $(DISDAT_DOCKER_CONTEXT)/Dockerfiles/02-user.dockerfile \
 		--tag $(PIPELINE_IMAGE_NAME) \
-		$(DOCKER_CONTEXT)
+		$(DISDAT_DOCKER_CONTEXT)
 
-build-03: $(DOCKER_CONTEXT)
+build-03: $(DISDAT_DOCKER_CONTEXT)
 	@echo "---------- Using SageMaker entrypoint"
 	docker build \
 		--build-arg IMAGE_LAYER=$(PIPELINE_IMAGE_NAME) \
-		--file $(DOCKER_CONTEXT)/Dockerfiles/03-sagemaker.dockerfile \
+		--file $(DISDAT_DOCKER_CONTEXT)/Dockerfiles/03-sagemaker.dockerfile \
 		--tag $(SAGEMAKER_TRAIN_IMAGE_NAME) \
-		$(DOCKER_CONTEXT)
+		$(DISDAT_DOCKER_CONTEXT)
 
 #
 # Set up the Docker context in which we build the image
 #
 
-context: $(DOCKER_CONTEXT)
+context: $(DISDAT_DOCKER_CONTEXT)
 
 # Copy the dockerizer support files into the Docker context. For this copy,
 # we DON'T want the directory name to be included in the copy.
-$(DOCKER_CONTEXT): $(shell find $(DOCKER_CONTEXT_TEMPLATE) \! -name '*.pyc' -type f)
+$(DISDAT_DOCKER_CONTEXT): $(shell find $(DISDAT_DOCKER_CONTEXT_TEMPLATE) \! -name '*.pyc' -type f)
 	@echo "----- Creating temporary Docker context in $@"
 	@if [ ! -d $@ ]; then mkdir $@; fi
-	rsync -av --delete --force $(DOCKER_CONTEXT_TEMPLATE)/ $@
+	rsync -av --delete --force $(DISDAT_DOCKER_CONTEXT_TEMPLATE)/ $@
 	@touch $@
 
 # Copy the user configuration files into the Docker context
-$(DOCKER_CONTEXT)/config: $(DOCKER_CONTEXT) $(shell find $(CONFIG_ROOT) -type f)
+$(DISDAT_DOCKER_CONTEXT)/config: $(DISDAT_DOCKER_CONTEXT) $(shell find $(CONFIG_ROOT) -type f)
 	@echo "----- Copying configuration files from $(CONFIG_ROOT)"
 	rsync -av --delete --force --quiet $(CONFIG_ROOT)/ $@
 	@touch $@
 
 # Copy Disdat into the Docker context
-$(DOCKER_CONTEXT)/disdat: $(DOCKER_CONTEXT) $(shell find $(DISDAT_ROOT)/disdat -type f)
+$(DISDAT_DOCKER_CONTEXT)/disdat: $(DISDAT_DOCKER_CONTEXT) $(shell find $(DISDAT_ROOT)/disdat -type f)
 	@echo "----- Copying Disdat files from $(DISDAT_ROOT)"
 	rsync -av --delete --force --quiet \
 		$(DISDAT_ROOT)/disdat/infrastructure/dockerizer $(DISDAT_ROOT)/disdat/infrastructure $@
@@ -184,7 +184,7 @@ $(DOCKER_CONTEXT)/disdat: $(DOCKER_CONTEXT) $(shell find $(DISDAT_ROOT)/disdat -
 
 # Copy the user pipeline package into the Docker context.
 # We assume the user has a setup.py that can create an sdist.
-$(DOCKER_CONTEXT)/pipeline: $(DOCKER_CONTEXT) $(shell find $(PIPELINE_ROOT) -not -path '*/\.*' -type f)
+$(DISDAT_DOCKER_CONTEXT)/pipeline: $(DISDAT_DOCKER_CONTEXT) $(shell find $(PIPELINE_ROOT) -not -path '*/\.*' -type f)
 	@echo "----- Copying pipeline $(PIPELINE_ROOT)"
 	cd $(PIPELINE_ROOT); \
 	    python setup.py sdist --dist-dir $@; cd -

--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/01-disdat-python.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/01-disdat-python.dockerfile
@@ -18,16 +18,11 @@ ARG DISDAT_SDIST
 # Copy the Disdat source to the temporary build root
 COPY disdat $BUILD_ROOT/disdat
 
-# ...and install Disdat
+# Create our virtual env
 RUN virtualenv $VIRTUAL_ENV
 
-# UGH.   setuptools 40.7.0 breaks pyodbc installs by passing in unicode to distutils and
-# it breaks looking for a type StringType, and not creating an array and then breaking when string doesn't have append
-# if 2.7.x-slim
-RUN ["/bin/bash", "-c", "source $VIRTUAL_ENV/bin/activate; pip install setuptools==40.6.0; pip install --no-cache-dir $BUILD_ROOT/disdat/dockerizer/context.template/$DISDAT_SDIST; deactivate"]
-
-# Use this line when we move to P3.
-# RUN ["/bin/bash", "-c", "source $VIRTUAL_ENV/bin/activate; pip install $BUILD_ROOT/disdat/dockerizer/context.template/$DISDAT_SDIST; deactivate"]
+# ...and install Disdat
+RUN ["/bin/bash", "-c", "source $VIRTUAL_ENV/bin/activate; pip install $BUILD_ROOT/disdat/dockerizer/context.template/$DISDAT_SDIST; deactivate"]
 
 # Add the virtual environment Python to the head of the PATH; running
 # `python` will then get you the installed virtual environment and the

--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
@@ -42,8 +42,8 @@ fi
 # NOTE: Since PIP 19.0 fails with --no-cache-dir, removed '-n' flag on kickstart-python.py script
 # NOTE: need to test with Python 3.6+
 RUN files=$(echo $BUILD_ROOT/config/python-sdist/*.tar.gz); if [ "$files" != $BUILD_ROOT/config/python-sdist/'*.tar.gz' ]; then \
+	$KICKSTART_ROOT/bin/kickstart-python.sh $VIRTUAL_ENV $i; \
 	for i in $files; do \
-		$KICKSTART_ROOT/bin/kickstart-python.sh $VIRTUAL_ENV $i; \
 		$KICKSTART_ROOT/bin/install-python-package-from-source-tree.sh $VIRTUAL_ENV $i; \
 	done; \
 fi

--- a/disdat/infrastructure/dockerizer/context.template/kickstart/bin/find_packages_from_setup.py
+++ b/disdat/infrastructure/dockerizer/context.template/kickstart/bin/find_packages_from_setup.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import argparse
-import imp
+import importlib as imp
 import mock
 import os
 import setuptools
@@ -54,4 +54,4 @@ if __name__ == '__main__':
     if not os.path.exists(args.setup_py):
         raise RuntimeError('Failed to find file {}'.format(args.setup_py))
 
-    print '\n'.join(find_packages(args.setup_py))
+    print ('\n'.join(find_packages(args.setup_py)))

--- a/disdat/infrastructure/dockerizer/context.template/kickstart/bin/kickstart-python.sh
+++ b/disdat/infrastructure/dockerizer/context.template/kickstart/bin/kickstart-python.sh
@@ -202,7 +202,7 @@ else
 		exit 1
 	fi
 
-	VIRTUALENV_VERSION=15.1.0
+	VIRTUALENV_VERSION=16.6.0
 	if [ $(virtualenv --version) != $VIRTUALENV_VERSION ]; then
 		warning "Expected virtualenv $VIRTUALENV_VERSION, got $(virtualenv --version)"
 	fi


### PR DESCRIPTION
1.) Fix Python 3 Print compat when installing sdist's into the container
2.) Fix compatibility issue with latest Docker Desktop release 2.1.0.1.   Docker build started using the DOCKER_CONTEXT env variable instead of the passed in context to the CLI command.  Since that variable was defined by our Makefile for building containers, it started to fail with "context dir does not exist."   