### PR TITLE
Jcessna/api add file

### DIFF
--- a/disdat/add.py
+++ b/disdat/add.py
@@ -40,10 +40,9 @@ def _add(args):
         return
 
     _ = api.add(fs._curr_context.get_local_name(),
-            args.bundle,
-            args.path_name,
-            tags=common.parse_args_tags(args.tag),
-            treat_file_as_bundle=args.inline_bundle)
+                args.bundle,
+                args.path_name,
+                tags=common.parse_args_tags(args.tag))
 
     return
 
@@ -58,8 +57,6 @@ def init_add_cl(subparsers):
     add_p = subparsers.add_parser('add', description='Create a bundle from a .csv, .tsv, or a directory of files.')
     add_p.add_argument('-t', '--tag', nargs=1, type=str, action='append',
                        help="Set one or more tags: 'dsdt add -t authoritative:True -t version:0.7.1'")
-    add_p.add_argument('-i', '--inline-bundle', action='store_true', default=False,
-                       help="Import a .tsv or a .csv file as an inline bundle.  Will present as a Pandas dataframe.")
     add_p.add_argument('bundle', type=str, help='The destination bundle in the current context')
     add_p.add_argument('path_name', type=str, help='File or directory of files to add to the bundle', action='store')
     add_p.set_defaults(func=lambda args: _add(args))

--- a/disdat/pipe_base.py
+++ b/disdat/pipe_base.py
@@ -374,7 +374,7 @@ class PipeBase(object):
 
         elif isinstance(val, tuple):
             presentation = hyperframe_pb2.ROW
-            for i, _ in enumerate(tuple):
+            for i, _ in enumerate(val):
                 frames.append(DataContext.convert_serieslike2frame(hfid, common.DEFAULT_FRAME_NAME + ':{}'.format(i), val, managed_path))
 
         elif isinstance(val, dict):

--- a/tests/functional/test_add.py
+++ b/tests/functional/test_add.py
@@ -214,7 +214,7 @@ def test_add_directory(tmpdir):
 
 
 @moto.mock_s3
-def test_add_with_treat_as_bundle(tmpdir):
+def deprecated_add_with_treat_as_bundle(tmpdir):
     api.context(context_name=TEST_CONTEXT)
 
     # Setup moto s3 resources
@@ -271,7 +271,9 @@ def test_add_with_treat_as_bundle(tmpdir):
     bundle_df_path = os.path.join(str(tmpdir), 'bundle.csv')
     bundle_df.to_csv(bundle_df_path)
 
+    # These are now deprecated
     # Add bundle dataframe
+
     api.add(TEST_CONTEXT, 'test_add_bundle', bundle_df_path, treat_file_as_bundle=True)
 
     # Assert that data in bundle is a dataframe
@@ -290,7 +292,7 @@ def test_add_with_treat_as_bundle(tmpdir):
     api.delete_context(TEST_CONTEXT)
 
 
-def test_data_as_bundle_not_csv(tmpdir):
+def deprecated_data_as_bundle_not_csv(tmpdir):
 
     # Create Context
     api.context(TEST_CONTEXT)

--- a/tests/functional/test_add.py
+++ b/tests/functional/test_add.py
@@ -78,7 +78,7 @@ def test_single_file(tmpdir):
     b = api.get(TEST_CONTEXT, 'test_single_file')
 
     # Assert the bundles contain the same data
-    bundle_hash, file_hash = get_hash(b.data[0]), get_hash(test_csv_path)
+    bundle_hash, file_hash = get_hash(b.data), get_hash(test_csv_path)
     assert bundle_hash == file_hash, 'Hashes do not match'
 
     # Test with tags
@@ -89,7 +89,7 @@ def test_single_file(tmpdir):
     b = api.get(TEST_CONTEXT, 'test_single_file')
 
     # Assert the bundles contain the same data
-    bundle_hash, file_hash = get_hash(b.data[0]), get_hash(test_csv_path)
+    bundle_hash, file_hash = get_hash(b.data), get_hash(test_csv_path)
     assert bundle_hash == file_hash, 'Hashes do not match'
     assert b.tags == tag, 'Tags do not match'
 


### PR DESCRIPTION
This pull request solves two issues:
1. I was not able to add a bundle using the python api that contains multiple files.  this is solved by allowing api.add to receive a path or iterable of paths as input
2. For a single-pathed bundle, the api.add created a different bundle then the bundles created automatically by task.run (that is, api.add would place the path inside a list).  this made it impossible to build clean load/save apis that were agnostic to how/where bundles were created.  this was fixed by having api.add return the filename (rather than [filename]) when there is only a single path in the bundle - just like the pipe.run api