### PR TITLE
Cache tasks from requires() before run

### DIFF
--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -266,6 +266,11 @@ class PipeTask(luigi.Task, PipeBase):
 
         assert(pce is not None)
 
+        """ NOTE: If a user changes a task param in run(), and that param parameterizes a dependency in requires(), 
+        then running requires() post run() will give different tasks.  To be safe we record the inputs before run() 
+        """
+        cached_bundle_inputs = self.bundle_inputs()
+
         try:
             start = time.time() #P3 datetime.now().timestamp()
             user_rtn_val = self.pipe_run(**kwargs)
@@ -284,7 +289,7 @@ class PipeTask(luigi.Task, PipeBase):
 
             hfr = PipeBase.make_hframe(frames,
                                        pce.uuid,
-                                       self.bundle_inputs(),
+                                       cached_bundle_inputs,
                                        self.pipeline_id(),
                                        self.pipe_id(),
                                        self,

--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -89,12 +89,13 @@ class PipeTask(luigi.Task, PipeBase):
 
         super(PipeTask, self).__init__(*args, **kwargs)
 
-        self.user_set_human_name = None
-        self.user_tags = {}
-        self.add_deps = {}
-        self.db_targets = []
-        self._input_tags = {}
-        self._mark_force = False
+        # Instance variables to track various user wishes
+        self.user_set_human_name = None  # self.set_bundle_name()
+        self.user_tags = {}              # self.add_tags()
+        self.add_deps = {}               # self.add(_external)_dependency()
+        self.db_targets = []             # Deprecating
+        self._input_tags = {}            # self.get_tags() of upstream tasks
+        self._mark_force = False         # self.mark_force()
 
     def bundle_outputs(self):
         """
@@ -384,13 +385,14 @@ class PipeTask(luigi.Task, PipeBase):
 
         kwargs = dict()
 
-        # Reset the stored tags, in case this instance is run multiple times.
-        self._input_tags = {}
-
         # Place upstream task outputs into the kwargs.  Thus the user does not call
         # self.inputs().  If they did, they would get a list of output targets for the bundle
         # that isn't very helpful.
         if for_run:
+
+            # Reset the stored tags, in case this instance is run multiple times.
+            self._input_tags = {}
+
             upstream_tasks = [(t.user_arg_name, self.pfs.get_path_cache(t)) for t in self.requires()]
             for user_arg_name, pce in [u for u in upstream_tasks if u[1] is not None]:
                 hfr = self.pfs.get_hframe_by_uuid(pce.uuid, data_context=self.data_context)
@@ -630,10 +632,10 @@ class PipeTask(luigi.Task, PipeBase):
         """
         Disdat Pipe API Function
 
-        Adds tags to bundle.
+        Retrieve the tag dictionary from an upstream task.
 
         Args:
-            user_arg_name (str): keyword arg name of input bundle for which to return tags
+            user_arg_name (str): keyword arg name of input bundle data for which to return tags
 
         Returns:
             tags (dict (str, str)): key value pairs (string, string)

--- a/tests/functional/test_tags.py
+++ b/tests/functional/test_tags.py
@@ -57,5 +57,4 @@ class TestContext:
 
 
 if __name__ == '__main__':
-    api.apply('examples', 'Destination')
-    #pytest.main([__file__])
+    pytest.main([__file__])

--- a/tests/functional/test_tags.py
+++ b/tests/functional/test_tags.py
@@ -57,4 +57,5 @@ class TestContext:
 
 
 if __name__ == '__main__':
-    pytest.main([__file__])
+    api.apply('examples', 'Destination')
+    #pytest.main([__file__])


### PR DESCRIPTION
This provides normal execution even if the user modifies a class luigi parameter in run that is also used to parameterize the tasks returned by `pipe_requires`.    After `pipe_run` Disdat calls `pipe_requires()` to determine the task's lineage.   If the requires function's behavior changed before / after the call to run, then the code would fail.   Now we cache the tasks before run and use them for establishing lineage post run.   