### PR TITLE
re-enable deser for parameters for CLI compat

### DIFF
--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -418,16 +418,24 @@ def convert_str_params(cls, params_str):
     all the input parameters are "strings" and we have to then put special code
     inside of apply to know when to create a class normally, or create it from the CLI.
 
-    :param params_str: dict of param name -> value as string.
+    Parameters:
+        params_str (dict): dict of str->str.  param name -> value .
     """
     kwargs = {}
-    for param_name, param in cls.get_params():
-        if param_name in params_str:
-            param_str = params_str[param_name]
+
+    cls_params = {n: p for n, p in cls.get_params()}  # get_params() returns [ (name, param), ... ]
+
+    for param_name, param_str in params_str.items():
+        if param_name in cls_params:
+            param = cls_params[param_name]
             if isinstance(param_str, list):
                 kwargs[param_name] = param._parse_list(param_str)
             else:
                 kwargs[param_name] = param.parse(param_str)
+        else:
+            _logger.error("Parameter {} is not defined in class {}.".format(param_name, cls.__name__))
+            raise ValueError("Parameter {} is not defined in class {}.".format(param_name, cls.__name__))
+
     return kwargs
 
 

--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -406,39 +406,6 @@ def resolve_bundle(pfs, pipe, is_left_edge_task, data_context):
     return use_bundle
 
 
-def convert_str_params(cls, params_str):
-    """
-    This is similar to Luigi.Task.from_str_params(cls, params_str)
-    But we don't create the class here.   We just want to convert
-    each of the params that are in the class and in this dictionary
-    into the deserialized form.
-
-    NOTE:  This is somewhat dangerous and could break if Luigi changes around
-    this code.  The alternative is to use Luigi.load_task() but then we have to ensure
-    all the input parameters are "strings" and we have to then put special code
-    inside of apply to know when to create a class normally, or create it from the CLI.
-
-    Parameters:
-        params_str (dict): dict of str->str.  param name -> value .
-    """
-    kwargs = {}
-
-    cls_params = {n: p for n, p in cls.get_params()}  # get_params() returns [ (name, param), ... ]
-
-    for param_name, param_str in params_str.items():
-        if param_name in cls_params:
-            param = cls_params[param_name]
-            if isinstance(param_str, list):
-                kwargs[param_name] = param._parse_list(param_str)
-            else:
-                kwargs[param_name] = param.parse(param_str)
-        else:
-            _logger.error("Parameter {} is not defined in class {}.".format(param_name, cls.__name__))
-            raise ValueError("Parameter {} is not defined in class {}.".format(param_name, cls.__name__))
-
-    return kwargs
-
-
 def cli_apply(args):
     """
     Parse and prepare strings from argparse arguments into suitable Python objects
@@ -458,9 +425,8 @@ def cli_apply(args):
         print("Apply unavailable -- Disdat not in a valid context.")
         return
 
-    # Create a dictionary of str->str arguments
-    user_params = common.parse_params(args.params) # a dictionary of str:str
-    deser_user_params = convert_str_params(args.pipe_cls, user_params)
+    # Create a dictionary of str->str arguments to str->python objects deser'd by Luigi Parameters
+    deser_user_params = common.parse_params(args.pipe_cls, args.params)
 
     input_tags = common.parse_args_tags(args.input_tag)
 

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -438,16 +438,62 @@ def parse_args_tags(args_tag, to='dict'):
     return tag_thing
 
 
-def parse_params(params):
+def parse_params(cls, params):
     """
+    Create a dictionary of str->str arguments to str->python objects deser'd by Luigi Parameters
+
     Input is the string "--arg value --arg2 value2"
-    Convert to dict {'arg':value,'arg2':value2}
 
-    :param params: from argparse
-    :return:   dict {'arg':value,'arg2':value2}
+    Convert to dict {'arg':str,'arg2':str2}
+
+    then
+
+    Convert to dict {'arg':luigi.Parameter.value,'arg2':luigi.Parameter.value2}
+
+    Args:
+        cls (type[disdat.pipe.PipeTask]):
+        params: from argparse
+
+    Returns:
+         dict {'arg':value,'arg2':value2}
     """
 
-    return {k.lstrip('--'): v for k, v in zip(params[::2], params[1::2])}
+    params_str_dict = {k.lstrip('--'): v for k, v in zip(params[::2], params[1::2])}
+
+    return convert_str_params(cls, params_str_dict)
+
+
+def convert_str_params(cls, params_str):
+    """
+    This is similar to Luigi.Task.from_str_params(cls, params_str)
+    But we don't create the class here, and we outer loop through our params (not the classes
+    params).  We just want to convert each of the params that are in the class and in this dictionary
+    into the deserialized form.
+
+    NOTE:  This is somewhat dangerous and could break if Luigi changes around
+    this code.  The alternative is to use Luigi.load_task() but then we have to ensure
+    all the input parameters are "strings" and we have to then put special code
+    inside of apply to know when to create a class normally, or create it from the CLI.
+
+    Parameters:
+        params_str (dict): dict of str->str.  param name -> value .
+    """
+    kwargs = {}
+
+    cls_params = {n: p for n, p in cls.get_params()}  # get_params() returns [ (name, param), ... ]
+
+    for param_name, param_str in params_str.items():
+        if param_name in cls_params:
+            param = cls_params[param_name]
+            if isinstance(param_str, list):
+                kwargs[param_name] = param._parse_list(param_str)
+            else:
+                kwargs[param_name] = param.parse(param_str)
+        else:
+            _logger.error("Parameter {} is not defined in class {}.".format(param_name, cls.__name__))
+            raise ValueError("Parameter {} is not defined in class {}.".format(param_name, cls.__name__))
+
+    return kwargs
 
 
 def get_local_file_path(url):

--- a/disdat/dsdt.py
+++ b/disdat/dsdt.py
@@ -43,15 +43,6 @@ DISDAT_PATH = os.environ.get("PATH", None)
 DISDAT_PYTHONPATH = os.environ.get("PYTHONPATH", None)
 
 
-def _apply(args):
-    """
-
-    :param args:
-    :return:
-    """
-    apply.main(args)
-
-
 def main():
     """
     Main as a function for testing convenience and as a package entry point.
@@ -107,7 +98,7 @@ def main():
     apply_p.add_argument('pipe_cls', type=load_class, help="User-defined transform, e.g., 'module.PipeClass'")
     apply_p.add_argument('params', type=str,  nargs=argparse.REMAINDER,
                          help="Optional set of parameters for this pipe '--parameter value'")
-    apply_p.set_defaults(func=lambda args: _apply(args))
+    apply_p.set_defaults(func=lambda args: apply.cli_apply(args))
 
     # File system operations
     init_fs_cl(subparsers)

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -200,15 +200,12 @@ def run_disdat_container(args):
         sys.exit(os.EX_IOERR)
 
     # If specified, decode the ordinary 'key:value' strings into a dictionary of tags.
-    input_tags = {}
-    if args.input_tag is not None:
-        input_tags = disdat.common.parse_args_tags(args.input_tag)
-    output_tags = {}
-    if args.output_tag is not None:
-        output_tags = disdat.common.parse_args_tags(args.output_tag)
+    input_tags = disdat.common.parse_args_tags(args.input_tag)
+    output_tags = disdat.common.parse_args_tags(args.output_tag)
 
     # Convert string of pipeline args into dictionary for api.apply
-    pipeline_args = disdat.common.parse_params(args.pipeline_args)
+    user_params = disdat.common.parse_params(args.pipeline_args)
+    deser_user_params = disdat.apply.convert_str_params(args.pipe_cls, user_params)
 
     # If the user wants final and intermediate, then inc push.
     if not args.no_push and not args.no_push_intermediates:
@@ -222,7 +219,7 @@ def run_disdat_container(args):
                                   output_bundle=args.output_bundle,
                                   input_tags=input_tags,
                                   output_tags=output_tags,
-                                  params=pipeline_args,
+                                  params=deser_user_params,
                                   output_bundle_uuid=args.output_bundle_uuid,
                                   force=args.force,
                                   workers=args.workers,
@@ -363,7 +360,7 @@ def main(input_args):
     pipeline_parser.add_argument(
         'pipeline',
         default=None,
-        type=str,
+        type=disdat.common.load_class,
         help=add_argument_help_string("Name of the pipeline class to run, e.g., 'package.module.ClassName'"),
     )
 

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -9,7 +9,6 @@ Entry point for pipelines run within Docker images.
 from __future__ import print_function
 
 import argparse
-import disdat.apply
 import disdat.common
 import disdat.fs
 import disdat.api
@@ -204,8 +203,7 @@ def run_disdat_container(args):
     output_tags = disdat.common.parse_args_tags(args.output_tag)
 
     # Convert string of pipeline args into dictionary for api.apply
-    user_params = disdat.common.parse_params(args.pipeline_args)
-    deser_user_params = disdat.apply.convert_str_params(args.pipe_cls, user_params)
+    deser_user_params = disdat.common.parse_params(args.pipe_cls, args.pipeline_args)
 
     # If the user wants final and intermediate, then inc push.
     if not args.no_push and not args.no_push_intermediates:

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -215,7 +215,7 @@ def run_disdat_container(args):
 
     try:
         result = disdat.api.apply(args.branch,
-                                  args.pipeline,
+                                  args.pipe_cls,
                                   output_bundle=args.output_bundle,
                                   input_tags=input_tags,
                                   output_tags=output_tags,
@@ -358,7 +358,7 @@ def main(input_args):
     )
 
     pipeline_parser.add_argument(
-        'pipeline',
+        'pipe_cls',
         default=None,
         type=disdat.common.load_class,
         help=add_argument_help_string("Name of the pipeline class to run, e.g., 'package.module.ClassName'"),


### PR DESCRIPTION
Issue 1: by removing the use of `luigi.load_class`, we removed our ability to parse command line arguments using luigi.Parameter's built-in ser/deser functionality.   However, we want to maintain api.apply as only taking in a dictionary of parameter values that are already native objects (not serialized json).   

Fix 1: Add a function to similar to that in `luigi.Task` that simply iterates through the task's parameters and deserializes any found in the input parameters before calling `api.apply`

Issue and Fix 2: The entrypoint for our containers would have experienced the identical issue.   So modify the entrypoint to also parse and deser parameters as appropriate before calling `api.apply`