### PR TITLE
Added get_bundle_uuid for tasks, improved api.pull

### DIFF
--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -278,7 +278,8 @@ def resolve_bundle(pfs, pipe, is_left_edge_task, data_context):
 
     # 1.) Get output bundle for pipe_id (the specific pipeline/transform/param hash).
 
-    if verbose: print("resolve_bundle: looking up bundle {}".format(pipe.pipe_id()))
+    if verbose:
+        print("resolve_bundle: looking up bundle {}".format(pipe.pipe_id()))
 
     if pipe._mark_force and not worker._is_external(pipe):
         # Forcing recomputation through a manual annotation in the pipe.pipe_requires() itself

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1480,6 +1480,15 @@ class DisdatFS(object):
             data_context.rebuild_db()
             return
 
+        if uuid is not None:
+            local_hfr = self.get_hframe_by_uuid(uuid, data_context=data_context)
+            if local_hfr is not None:
+                if localize:
+                    # TODO: Need fast check to see if it is already localized!
+                    DisdatFS._localize_hfr(local_hfr, uuid, data_context)
+                return
+            # else fall through to see if we can pull from remote context
+
         #start = time.time()
         possible_hframe_objects = aws_s3.ls_s3_url_objects(data_context.get_remote_object_dir())
         #print "List time {} seconds".format(time.time() - start)


### PR DESCRIPTION
Tasks can now call `self.get_bundle_uuid(<input arg name>)` and get the bundle uuid. 
Also improved api.pull so that, if the user specifies pull by uuid, we check to see if we have it locally, without ls-ing all the keys on S3 in the context. 