### PR TITLE
Do not use output tags when computing processing name

### DIFF
--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -63,7 +63,7 @@ class PipeTask(luigi.Task, PipeBase):
     driver_output_bundle = luigi.Parameter(default='None', significant=False)
 
     force = luigi.BoolParameter(default=False, significant=False)
-    output_tags = luigi.DictParameter(default={}, significant=True)
+    output_tags = luigi.DictParameter(default={}, significant=False)
 
     # Each pipeline executes wrt a data context.
     data_context = luigi.Parameter(default=None, significant=False)


### PR DESCRIPTION
Disdat bundles have a human name,  `tto_forecast_data`, and a processing name like `forecast_data_ab329h`.   The processing name is what Disdat uses to identify data that has been created by a task.

This PR removes output tags from the computation of the processing name.

At the moment, you can tag output bundles with anything.   And those tags are used to compute the processing name.   So if you make a bundle with a tag, you have to use the same tag when you add your dependency to get the same data.    I don’t think this is right, since, if your tag changes the output, then it should be a task parameter instead.    In addition, there’s no way to specify tags in add_dependency, so there’s no way to request that data programmatically in a pipeline.     