### PR TITLE
Fix add_external_dependency bug

### DIFF
--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -530,7 +530,7 @@ class PipeTask(luigi.Task, PipeBase):
             elif human_name is not None:
                 hfr = self.pfs.get_latest_hframe(human_name, data_context=self.data_context)
             else:
-                p = task_class(params)
+                p = task_class(**params)
                 hfr = self.pfs.get_hframe_by_proc(p.pipe_id(), data_context=self.data_context)
 
             bundle = api.Bundle(self.data_context.get_local_name(), 'unknown')
@@ -543,7 +543,7 @@ class PipeTask(luigi.Task, PipeBase):
             self.add_deps[param_name] = (luigi.task.externalize(task_class), params)
 
         except Exception as error:
-            _logger.warning("Unable to resolve external bundle by processing name({}): {}".format(p.pipe_id(), error))
+            _logger.warning("Unable to resolve external bundle made by class ({}): {}".format(task_class, error))
             return None
 
         return bundle

--- a/tests/functional/test_external_dep.py
+++ b/tests/functional/test_external_dep.py
@@ -21,25 +21,28 @@ from disdat.pipe import PipeTask
 import disdat.api as api
 from tests.functional.common import run_test, TEST_CONTEXT # autouse fixture to setup / tear down context
 
-TEST_BUNDLE_NAME='test_bundle_name'
+EXT_BUNDLE_NAME='ext_bundle_human_name'
 BUNDLE_CONTENTS=list(range(9))
+EXT_TASK_PARAM_VAL='this is a test value'
 
 
 class ExternalPipeline(PipeTask):
+    test_param = luigi.Parameter()
+
     """ External Pipeline """
     def pipe_requires(self):
         self.set_bundle_name('external_pipeline')
 
     def pipe_run(self):
+        print ("ExternalPipeline called with parameter [{}]".format(self.test_param))
         return BUNDLE_CONTENTS
 
 
 class PipelineA(PipeTask):
-    ext_name = luigi.Parameter(default=ExternalPipeline)
 
     def pipe_requires(self):
         self.set_bundle_name('pipeline_a')
-        b = self.add_external_dependency('ext_input', self.ext_name, {})
+        b = self.add_external_dependency('ext_input', ExternalPipeline, {'test_param': EXT_TASK_PARAM_VAL})
         assert list(b.data) == BUNDLE_CONTENTS
 
     def pipe_run(self, ext_input=None):
@@ -52,7 +55,26 @@ class PipelineB(PipeTask):
 
     def pipe_requires(self):
         self.set_bundle_name('pipeline_b')
-        b = self.add_external_dependency('ext_input', ExternalPipeline, {}, uuid=self.ext_uuid)
+        b = self.add_external_dependency('ext_input',
+                                         ExternalPipeline,
+                                         {'test_param': EXT_TASK_PARAM_VAL},
+                                         uuid=self.ext_uuid)
+        assert list(b.data) == BUNDLE_CONTENTS
+
+    def pipe_run(self, ext_input=None):
+        assert list(ext_input) == BUNDLE_CONTENTS
+        return True
+
+
+class PipelineC(PipeTask):
+    ext_name = luigi.Parameter()
+
+    def pipe_requires(self):
+        self.set_bundle_name('pipeline_b')
+        b = self.add_external_dependency('ext_input',
+                                         ExternalPipeline,
+                                         {'test_param': EXT_TASK_PARAM_VAL},
+                                         human_name=self.ext_name)
         assert list(b.data) == BUNDLE_CONTENTS
 
     def pipe_run(self, ext_input=None):
@@ -64,21 +86,42 @@ def create_bundle_from_pipeline():
     """ Run the internal pipeline, create a bundle, return the uuid
     """
 
-    api.apply(TEST_CONTEXT, ExternalPipeline)
-    b = api.get(TEST_CONTEXT, 'external_pipeline')
+    api.apply(TEST_CONTEXT,
+              ExternalPipeline,
+              params={'test_param': EXT_TASK_PARAM_VAL},
+              output_bundle=EXT_BUNDLE_NAME)
+    b = api.get(TEST_CONTEXT, EXT_BUNDLE_NAME)
     return b.uuid
 
 
-def test_external_dependency():
-    #assert len(api.search(TEST_CONTEXT)) == 0, 'Context should be empty'
+def test_ord_external_dependency():
 
     uuid = create_bundle_from_pipeline()
 
     print ("UUID of created bundle is {}".format(uuid))
 
+    # Ordinary ext dep
     api.apply(TEST_CONTEXT, PipelineA)
 
+
+def test_uuid_external_dependency():
+
+    uuid = create_bundle_from_pipeline()
+
+    print ("UUID of created bundle is {}".format(uuid))
+
+    # Ext dep by specific UUID
     api.apply(TEST_CONTEXT, PipelineB, params={'ext_uuid': uuid})
+
+
+def test_name_external_dependency():
+
+    uuid = create_bundle_from_pipeline()
+
+    print ("UUID of created bundle is {}".format(uuid))
+
+    # Ext dep by human name
+    api.apply(TEST_CONTEXT, PipelineC, params={'ext_name': EXT_BUNDLE_NAME})
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
When not supplying a uuid or a human_name the code was trying to instantiate the class without dereferencing the kwargs, i.e., `task_class(**params)`.  

Also, added tests for this case, which were missing before and allowed this bug to pass unknown. 