### PR TITLE
Fix dockerize (replace easy_install with pip)

### DIFF
--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/00-disdat-python-3.6.8-slim.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/00-disdat-python-3.6.8-slim.dockerfile
@@ -19,7 +19,7 @@ RUN apt-get upgrade -y
 # disdat uses pyodbc which requires gcc ,hence 'build-essential'
 # sometimes people need to install .deb files, hence gdebi
 RUN apt-get install -y git build-essential unixodbc-dev
-RUN easy_install virtualenv
+RUN pip install virtualenv==16.7.9
 
 # Install the kickstart scripts used by later layers
 COPY kickstart $KICKSTART_ROOT

--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
@@ -51,7 +51,6 @@ fi
 
 # Install user Python sdist package dependencies
 # NOTE: Since PIP 19.0 fails with --no-cache-dir, removed '-n' flag on kickstart-python.py script
-# NOTE: need to test with Python 3.6+
 RUN files=$(echo $BUILD_ROOT/config/python-sdist/*.tar.gz); if [ "$files" != $BUILD_ROOT/config/python-sdist/'*.tar.gz' ]; then \
 	$KICKSTART_ROOT/bin/kickstart-python.sh $VIRTUAL_ENV $i; \
 	for i in $files; do \


### PR DESCRIPTION
At the beginning of dockerize, easy_install was used to install virtualenv.
It began to install version 20.0.0b1.
This broke dockerization because activate and deactivate were no longer in the virtualenv/bin directory.   
Replaced easy_install with pip and nailed it to 16.7.9 (latest as of now). 