### PR TITLE
Remove uncommitted history

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -119,7 +119,7 @@ class BundleWrapperTask(PipeTask):
         """ Determine input bundles """
         raise NotImplementedError
 
-    def pipeline_id(self):
+    def human_id(self):
         """ default is shortened version of pipe_id
         But here we want it to be the set name """
         return self.name
@@ -553,7 +553,7 @@ class Bundle(HyperFrameRecord):
             wrapper_task(Luigi.Task)
 
         """
-        self.pb.processing_name = wrapper_task.pipe_id()
+        self.pb.processing_name = wrapper_task.processing_id()
 
         return self.pb.processing_name
 

--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -294,7 +294,7 @@ def resolve_bundle(pfs, pipe, is_left_edge_task, data_context):
     # 1.) Get output bundle for pipe_id (the specific pipeline/transform/param hash).
 
     if verbose:
-        print("resolve_bundle: looking up bundle {}".format(pipe.pipe_id()))
+        print("resolve_bundle: looking up bundle {}".format(pipe.processing_id()))
 
     if pipe._mark_force and not worker._is_external(pipe):
         # Forcing recomputation through a manual annotation in the pipe.pipe_requires() itself
@@ -312,9 +312,9 @@ def resolve_bundle(pfs, pipe, is_left_edge_task, data_context):
         pfs.new_output_hframe(pipe, is_left_edge_task, data_context=data_context)
         return regen_bundle
 
-    bndls = pfs.get_hframe_by_proc(pipe.pipe_id(), getall=True, data_context=data_context)
+    bndls = pfs.get_hframe_by_proc(pipe.processing_id(), getall=True, data_context=data_context)
     if bndls is None or len(bndls) <= 0:
-        if verbose: print("resolve_bundle: No bundle with proc_name {}, getting new output bundle.\n".format(pipe.pipe_id()))
+        if verbose: print("resolve_bundle: No bundle with proc_name {}, getting new output bundle.\n".format(pipe.processing_id()))
         # no bundle, force recompute
         pfs.new_output_hframe(pipe, is_left_edge_task, data_context=data_context)
         return regen_bundle
@@ -342,7 +342,7 @@ def resolve_bundle(pfs, pipe, is_left_edge_task, data_context):
     # because, at the moment, we make new bundles when we change name.  When in some sense
     # it's just a tag set that should include other names and the data should be the same.
 
-    current_human_name = pipe.pipeline_id()
+    current_human_name = pipe.human_id()
     found = False
     for bndl in bndls:
         if current_human_name == bndl.get_human_name():

--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -697,7 +697,9 @@ class DataContext(object):
         for fr in hfr.get_frames(self):
             hyperframe.w_pb_db(fr, self.local_engine)
 
-        self.prune_uncommitted_history(hfr.pb.human_name)
+        # Todo: Make it an option
+        # Note: We are changing the default human_name to be only the task name
+        # self.prune_uncommitted_history(hfr.pb.human_name)
 
         return result
 

--- a/disdat/driver.py
+++ b/disdat/driver.py
@@ -78,7 +78,7 @@ class DriverTask(luigi.WrapperTask, PipeBase):
         """
 
         output_tasks = self.deps()
-        output_bundles = [(task.pipe_id(), self.pfs.get_path_cache(task).uuid) for task in output_tasks]
+        output_bundles = [(task.processing_id(), self.pfs.get_path_cache(task).uuid) for task in output_tasks]
 
         return output_bundles
 
@@ -99,7 +99,7 @@ class DriverTask(luigi.WrapperTask, PipeBase):
         """
 
         input_tasks = self.deps()
-        input_bundles = [(task.pipe_id(), self.pfs.get_path_cache(task).uuid) for task in input_tasks]
+        input_bundles = [(task.processing_id(), self.pfs.get_path_cache(task).uuid) for task in input_tasks]
         return input_bundles
 
     def pipe_id(self):

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -227,7 +227,7 @@ class DisdatFS(object):
 
         """
 
-        pipe_name = pipe_instance.pipe_id()
+        pipe_name = pipe_instance.processing_id()
 
         return DisdatFS.get_path_cache_by_name(pipe_name)
 
@@ -272,7 +272,7 @@ class DisdatFS(object):
             pce or raise KeyError
 
         """
-        pipe_name = pipe_instance.pipe_id()
+        pipe_name = pipe_instance.processing_id()
         pce = PipeCacheEntry(pipe_instance, uuid, path, rerun, is_left_edge_task)
         if pipe_name not in DisdatFS.task_path_cache:
             DisdatFS.task_path_cache[pipe_name] = pce

--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -104,7 +104,7 @@ class PipeTask(luigi.Task, PipeBase):
         For now: Apply Output Bundle "-" Pipe Class Name
         """
 
-        output_bundles = [(self.pipe_id(), self.pfs.get_path_cache(self).uuid)]
+        output_bundles = [(self.processing_id(), self.pfs.get_path_cache(self).uuid)]
         return output_bundles
 
     def bundle_inputs(self):
@@ -120,22 +120,22 @@ class PipeTask(luigi.Task, PipeBase):
         """
 
         input_tasks = self.deps()
-        input_bundles = [(task.pipe_id(), self.pfs.get_path_cache(task).uuid) for task in input_tasks]
+        input_bundles = [(task.processing_id(), self.pfs.get_path_cache(task).uuid) for task in input_tasks]
         return input_bundles
 
-    def pipe_id(self):
+    def processing_id(self):
         """
         Given a pipe instance, return the "processing_name" -- a unique string based on the class name and
         the parameters.  This re-uses Luigi code for getting the unique string.
 
-        NOTE: The PipeTask has a 'driver_output_bundle'.  This the name of the pipline output bundle given by the user.
+        NOTE: The PipeTask has a 'driver_output_bundle'.  This the name of the pipeline output bundle given by the user.
         Because this is a Luigi parameter, it is included in the Luigi self.task_id string and hash.  So we do not
         have to append this separately.
 
         """
         return self.task_id
 
-    def pipeline_id(self):
+    def human_id(self):
         """
         This is the "human readable" name;  a "less unique" id than the unique id.
 
@@ -158,8 +158,8 @@ class PipeTask(luigi.Task, PipeBase):
         elif self.user_set_human_name is not None:
             return self.user_set_human_name
         else:
-            id_parts = self.pipe_id().split('_')
-            return "{}_{}".format(id_parts[0],id_parts[-1])
+            id_parts = self.processing_id().split('_')
+            return "{}".format(id_parts[0])
 
     def get_hframe_uuid(self):
         """ Return the unique ID for this tasks current output hyperframe
@@ -287,8 +287,8 @@ class PipeTask(luigi.Task, PipeBase):
             hfr = PipeBase.make_hframe(frames,
                                        pce.uuid,
                                        cached_bundle_inputs,
-                                       self.pipeline_id(),
-                                       self.pipe_id(),
+                                       self.human_id(),
+                                       self.processing_id(),
                                        self,
                                        start_ts=start,
                                        stop_ts=stop,
@@ -533,7 +533,7 @@ class PipeTask(luigi.Task, PipeBase):
                 hfr = self.pfs.get_latest_hframe(human_name, data_context=self.data_context)
             else:
                 p = task_class(**params)
-                hfr = self.pfs.get_hframe_by_proc(p.pipe_id(), data_context=self.data_context)
+                hfr = self.pfs.get_hframe_by_proc(p.processing_id(), data_context=self.data_context)
 
             if hfr is None:
                 raise ExtDepError("Unable to resolve external bundle made by class ({})".format(task_class))

--- a/disdat/pipe_base.py
+++ b/disdat/pipe_base.py
@@ -74,7 +74,7 @@ class PipeBase(object):
         pass
 
     @abstractmethod
-    def pipe_id(self):
+    def processing_id(self):
         """
         Given a pipe instance, return a unique string based on the class name and
         the parameters.
@@ -84,7 +84,7 @@ class PipeBase(object):
         pass
 
     @abstractmethod
-    def pipeline_id(self):
+    def human_id(self):
         """
         This is a "less unique" id than the unique id.  It is supposed to be the "human readable" name of the stage
         this pipe occupies in the pipesline.
@@ -116,9 +116,9 @@ class PipeBase(object):
 
         if pce is None:
             # This can happen when the pipe has been created with non-deterministic parameters
-            _logger.error("add_bundle_meta_files: could not find pce for task {}".format(pipe_task.pipe_id()))
+            _logger.error("add_bundle_meta_files: could not find pce for task {}".format(pipe_task.processing_id()))
             _logger.error("It is possible one of your tasks is parameterized in a non-deterministic fashion.")
-            raise Exception("add_bundle_meta_files: Unable to find pce for task {}".format(pipe_task.pipe_id()))
+            raise Exception("add_bundle_meta_files: Unable to find pce for task {}".format(pipe_task.processing_id()))
 
         hframe = {PipeBase.HFRAME: luigi.LocalTarget(os.path.join(pce.path, HyperFrameRecord.make_filename(pce.uuid)))}
 
@@ -320,7 +320,7 @@ class PipeBase(object):
 
         elif isinstance(val, HyperFrameRecord):
             presentation = hyperframe_pb2.HF
-            frames.append(FrameRecord.make_hframe_frame(hfid, pipe.pipeline_id(), [val]))
+            frames.append(FrameRecord.make_hframe_frame(hfid, pipe.human_id(), [val]))
 
         elif isinstance(val, np.ndarray) or isinstance(val, list):
             presentation = hyperframe_pb2.TENSOR


### PR DESCRIPTION
Remove uncommitted history feature. 
This feature yields unexpected behavior to the user in the form of:
a.) Default human_names are <class name>_<hash(task params)>, which mirrors processing name.  
b.) Additional versions before commit automagically disappear.  

So
1.) Default human_names are now just <class name>
2.) We can add features to `dsdt rm` to emulate this behavior. 