### PR TITLE
improved re-run semantics via processing name 

### DIFF
--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -34,6 +34,7 @@ author: Kenneth Yocum
 
 import os
 import time
+import hashlib
 
 import luigi
 
@@ -119,8 +120,8 @@ class PipeTask(luigi.Task, PipeBase):
 
         """
 
-        input_tasks = self.deps()
-        input_bundles = [(task.processing_id(), self.pfs.get_path_cache(task).uuid) for task in input_tasks]
+        input_bundles = [(task.processing_id(), self.pfs.get_path_cache(task).uuid) for task in self.deps()]
+
         return input_bundles
 
     def processing_id(self):
@@ -128,12 +129,48 @@ class PipeTask(luigi.Task, PipeBase):
         Given a pipe instance, return the "processing_name" -- a unique string based on the class name and
         the parameters.  This re-uses Luigi code for getting the unique string.
 
+        processing_id = task_class_name + hash(task params +  [ dep0_task_name + hash(dep0_params),
+                        dep1_task_name + hash(dep1_params),...])
+
+        In typical Luigi workflows, a task's parameters uniquely determine the requires function outputs.
+
+        Thus there is no need to include the data inputs in the uniqueness of the processing name.
+
+        But, some facilities on top of Disdat might build dynamic classes.   In these cases, upper layer code
+        might define a pipeline in python like:
+        ```
+        @punch.task
+        def adder(a,b):
+            return a+b
+
+        def pipeline(X):
+            u = adder(a=1, b=2)
+            v = adder(a=u, b=X+1)
+            w = adder(a=v, b=X+2)
+        ```
+
+        In this case, there is a new task for each `adder`.  Each`adder`'s requirements are defined in a scope outside
+         of the dynamic classes requires method.
+
         NOTE: The PipeTask has a 'driver_output_bundle'.  This the name of the pipeline output bundle given by the user.
         Because this is a Luigi parameter, it is included in the Luigi self.task_id string and hash.  So we do not
         have to append this separately.
 
         """
-        return self.task_id
+
+        deps = self.requires()
+
+        assert(isinstance(deps, dict))
+
+        input_task_processing_ids = [(deps[k]).processing_id() for k in sorted(deps)]
+
+        as_one_str = '.'.join(input_task_processing_ids)
+
+        param_hash = hashlib.md5(as_one_str.encode('utf-8')).hexdigest()
+
+        processing_id = self.task_id + '_' + param_hash[:luigi.task.TASK_ID_TRUNCATE_HASH]
+
+        return processing_id
 
     def human_id(self):
         """
@@ -180,7 +217,7 @@ class PipeTask(luigi.Task, PipeBase):
             (:list:`hyperframe.HyperFrameRecord`): list of upstream hyperframes
         """
 
-        tasks = self.requires()
+        tasks = self.deps()
         hfrs = []
         for t in tasks:
             hfid = t.get_hframe_uuid()
@@ -196,7 +233,10 @@ class PipeTask(luigi.Task, PipeBase):
         1.) The input_df so far stays the same for all upstream pipes.
         2.) However, when we resolve the location of the outputs, we need to do so correctly.
 
-        :return:
+        Args:
+
+        Returns:
+            (dict): arg_name: task_class
         """
 
         kwargs = self.prepare_pipe_kwargs()
@@ -206,9 +246,9 @@ class PipeTask(luigi.Task, PipeBase):
         rslt = self.add_deps
 
         if len(self.add_deps) == 0:
-            return []
+            return {}
 
-        tasks = []
+        tasks = {}
 
         for user_arg_name, cls_and_params in rslt.items():
             pipe_class, params = cls_and_params[0], cls_and_params[1]
@@ -226,7 +266,7 @@ class PipeTask(luigi.Task, PipeBase):
                 'incremental_push': self.incremental_push,  # propagate the choice to push incremental data.
                 'incremental_pull': self.incremental_pull  # propagate the choice to incrementally pull data.
             })
-            tasks.append(pipe_class(**params))
+            tasks[user_arg_name] = pipe_class(**params)
 
         return tasks
 
@@ -397,7 +437,7 @@ class PipeTask(luigi.Task, PipeBase):
             self._input_tags = {}
             self._input_bundle_uuids = {}
 
-            upstream_tasks = [(t.user_arg_name, self.pfs.get_path_cache(t)) for t in self.requires()]
+            upstream_tasks = [(t.user_arg_name, self.pfs.get_path_cache(t)) for t in self.deps()]
             for user_arg_name, pce in [u for u in upstream_tasks if u[1] is not None]:
                 hfr = self.pfs.get_hframe_by_uuid(pce.uuid, data_context=self.data_context)
                 assert hfr.is_presentable()

--- a/disdat/pipe.py
+++ b/disdat/pipe.py
@@ -87,6 +87,8 @@ class PipeTask(luigi.Task, PipeBase):
 
         super(PipeTask, self).__init__(*args, **kwargs)
 
+        self._cached_processing_id = None
+
         # Instance variables to track various user wishes
         self.user_set_human_name = None  # self.set_bundle_name()
         self.user_tags = {}              # self.add_tags()
@@ -158,6 +160,9 @@ class PipeTask(luigi.Task, PipeBase):
 
         """
 
+        if self._cached_processing_id is not None:
+            return self._cached_processing_id
+
         deps = self.requires()
 
         assert(isinstance(deps, dict))
@@ -169,6 +174,8 @@ class PipeTask(luigi.Task, PipeBase):
         param_hash = hashlib.md5(as_one_str.encode('utf-8')).hexdigest()
 
         processing_id = self.task_id + '_' + param_hash[:luigi.task.TASK_ID_TRUNCATE_HASH]
+
+        self._cached_processing_id = processing_id
 
         return processing_id
 
@@ -425,7 +432,6 @@ class PipeTask(luigi.Task, PipeBase):
             (dict): A dictionary with the arguments.
 
         """
-
         kwargs = dict()
 
         # Place upstream task outputs into the kwargs.  Thus the user does not call
@@ -473,7 +479,6 @@ class PipeTask(luigi.Task, PipeBase):
         Returns:
 
         """
-
         return None
 
     def pipe_run(self, **kwargs):
@@ -491,7 +496,6 @@ class PipeTask(luigi.Task, PipeBase):
         Returns:
 
         """
-
         raise NotImplementedError()
 
     def add_dependency(self, name, task_class, params):
@@ -509,7 +513,6 @@ class PipeTask(luigi.Task, PipeBase):
             None
 
         """
-
         if not isinstance(params, dict):
             error = "add_dependency third argument must be a dictionary of parameters"
             raise Exception(error)
@@ -672,7 +675,6 @@ class PipeTask(luigi.Task, PipeBase):
             (`luigi.contrib.s3.S3Target`): Singleton, list, or dictionary of Luigi Target objects.
 
         """
-
         pce = self.pfs.get_path_cache(self)
         assert (pce is not None)
         output_dir = self.get_output_dir_remote()
@@ -693,7 +695,6 @@ class PipeTask(luigi.Task, PipeBase):
             output_dir (str):  Fully qualified path of a directory whose prefix is the bundle's local output directory.
 
         """
-
         prefix_dir = self.get_output_dir()
         fqp = os.path.join(prefix_dir, dirname)
         try:
@@ -757,7 +758,6 @@ class PipeTask(luigi.Task, PipeBase):
             raise Exception('Managed S3 path creation needs a) remote context and b) incremental push to be set')
         return output_dir
 
-
     def set_bundle_name(self, human_name):
         """
         Disdat Pipe API Function
@@ -772,7 +772,6 @@ class PipeTask(luigi.Task, PipeBase):
             None
 
         """
-
         self.user_set_human_name = human_name
 
     def add_tags(self, tags):

--- a/tests/functional/test_requires.py
+++ b/tests/functional/test_requires.py
@@ -15,11 +15,8 @@
 #
 
 
-import os
-import hashlib
+
 import pytest
-import pandas as pd
-from numpy import random
 
 import disdat.api as api
 from tests.functional.common import run_test, TEST_CONTEXT

--- a/tests/functional/test_reuse_logic.py
+++ b/tests/functional/test_reuse_logic.py
@@ -323,3 +323,5 @@ class C(PipeTask):
 
 if __name__ is '__main__':
     pytest.main([__file__])
+
+

--- a/tests/functional/test_reuse_logic.py
+++ b/tests/functional/test_reuse_logic.py
@@ -1,0 +1,325 @@
+#
+# Copyright 2017 Human Longevity, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import pytest
+import luigi
+from disdat.pipe import PipeTask
+import disdat.api as api
+from tests.functional.common import run_test, TEST_CONTEXT, setup
+
+""" This set of tests verifies the behavior of Disdat's re-execution / data re-use logic.
+ 
+ Luigi has a simple re-run logic: do not re-run tasks when the targets returned by the output function exist.
+ 
+ Note that because task parameters should define up-stream dependencies, a given task should only re-use its result
+ when its upstream required tasks have also re-used their results.  If a tasks parameters have not changed, its dependencies
+ should not change, those cached results may be used, and so on.  
+ 
+ But tasks with the same parameters may be re-executed for a variety of real-world reasons.  First, the task code may have 
+ changed.  Or the task may be reading from an external data source that has changed (a database table).  While this 
+ second case should be handled by the programmer (parameterizing by the time of db access), the programmer may forget or 
+ the time unit may not be of sufficient granularity.   E.g., parametrize by day read, but the database changes more frequently.
+ Or an external up-stream input, produced by another pipeline, has been updated.  
+ 
+ In addition, it is possible for a layer above Disdat (or Luigi), could dynamically create tasks, and parameterize them
+ outside of the normal pattern of "right-to-left" or "last task passes parameters to first task" pattern. 
+ 
+ Finally, Disdat de-couples absolute file paths (used in Luigi) from the logical name of a task's output.  What this 
+ means is that absolute file paths alone do not dictate whether a task should re-use that output.  Instead, whether any 
+ *version* of a parameterized task's output exists determines if it should re-run.  
+ 
+ In all of these cases, the downstream task should be re-run when new versions of upstream outputs exist.  Disdat builds 
+ upon Luigi's straightforward logic to determine whether to re-execute or re-use existing outputs in these conditions. 
+ 
+ In particular, Disdat uses the processing_name as the notion of versioning "sameness" for re-use.  The processing name
+ is, a summary of the current task's parameters and a summary of the parameters of its upstream tasks.  In essence, it is 
+ is analogous to a Merkle Tree, summarizing the state of the world used to run a single task.   
+ 
+ Note that UUIDs are "lineage" names.  They tell us exactly the data used to produce an output.      
+  
+  Tests: * means new params
+  1.) Force and Force all are handled by test_force_one_and_all.py
+  2.) Run A, Run A, should re-use
+  3.) Run A, Run A*, should re-run
+  4.) Run A->B, Re-run A*.  Run A->B, nothing should run. 
+  5.) Run A->B, re-run A (force), Run A->B, B should re-run. 
+  6.) Run A->B, Re-run A*.  Run A*->B, B should re-run. 
+  7.) Run A->B->C,  Run A*->B.   Run A->B->C, nothing should run
+  8.) Run A->B->C,  Run A*->B.   Run A*->B->C, C should re-run
+  9.) Run A,B -> C(a=A,b=B) Run A,B -> C(a=B,b=A), C should run both times.  
+   
+ """
+
+
+def test_A2_A3(run_test):
+    """
+    2.) Run A, Run A, should re-use
+    3.) Run A, Run A*, should re-run
+    """
+
+    result = api.apply(TEST_CONTEXT, A)
+    assert result['did_work'] is True
+    first_A_uuid = api.get(TEST_CONTEXT, 'A').uuid
+    result = api.apply(TEST_CONTEXT, A)
+    assert result['did_work'] is False
+    second_A_uuid = api.get(TEST_CONTEXT, 'A').uuid
+    assert first_A_uuid == second_A_uuid
+    assert len(api.search(TEST_CONTEXT, 'A')) is 1
+
+    # Mod args, should re-run
+    result = api.apply(TEST_CONTEXT, A, params={'a': 2,'b': 3})
+    assert result['did_work'] is True
+    next_A_uuid = api.get(TEST_CONTEXT, 'A').uuid
+    assert next_A_uuid != second_A_uuid
+    assert len(api.search(TEST_CONTEXT, 'A')) is 2
+
+
+def test_AB4(run_test):
+    """
+    4.) Run A->B, Re-run A*.  Run A->B, nothing should run.
+    """
+
+    result = api.apply(TEST_CONTEXT, B)
+    assert result['success'] is True
+    assert result['did_work'] is True
+
+    result = api.apply(TEST_CONTEXT, A, params={'a':2, 'b':3})
+    assert result['success'] is True
+    assert result['did_work'] is True
+
+    result = api.apply(TEST_CONTEXT, B)
+    assert result['success'] is True
+    assert result['did_work'] is False
+
+
+def test_AB5(run_test):
+    """
+    5.) Run A->B, re-run A (force), Run A->B, B should re-run.
+    """
+
+    result = api.apply(TEST_CONTEXT, B)
+    assert result['success'] is True
+    assert result['did_work'] is True
+
+    result = api.apply(TEST_CONTEXT, A, force=True)
+    assert result['success'] is True
+    assert result['did_work'] is True
+
+    result = api.apply(TEST_CONTEXT, B)
+    assert result['success'] is True
+    assert result['did_work'] is True
+
+
+def test_AB6(run_test):
+    """
+    6.) Run A->B, Re-run A*.  Run A*->B, B should re-run.
+
+    Args:
+        run_test:
+
+    Returns:
+
+    """
+
+    result = api.apply(TEST_CONTEXT, B)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    B_uuid = api.get(TEST_CONTEXT, 'B').uuid
+
+    result = api.apply(TEST_CONTEXT, APrime)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    APrime_uuid = api.get(TEST_CONTEXT, 'APrime').uuid
+
+    def custom_B_requires(self):
+        self.add_dependency('a', APrime, params={})
+
+    old_requires = B.pipe_requires
+    B.pipe_requires = custom_B_requires
+
+    result = api.apply(TEST_CONTEXT, B)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    assert APrime_uuid == api.get(TEST_CONTEXT, 'APrime').uuid
+    assert B_uuid != api.get(TEST_CONTEXT, 'B').uuid
+
+    B.pipe_requires = old_requires
+
+
+def test_ABC7(run_test):
+    """
+    7.) Run A->B->C,  Run A*->B.   Run A->B->C, nothing should run
+
+    Args:
+        run_test:
+
+    Returns:
+
+    """
+
+    result = api.apply(TEST_CONTEXT, C)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    B_uuid = api.get(TEST_CONTEXT, 'B').uuid
+
+    def custom_B_requires(self):
+        self.add_dependency('a', APrime, params={})
+
+    old_requires = B.pipe_requires
+    B.pipe_requires = custom_B_requires
+
+    result = api.apply(TEST_CONTEXT, B)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    assert B_uuid != api.get(TEST_CONTEXT, 'B').uuid  # should have a new B
+
+    B.pipe_requires = old_requires
+
+    result = api.apply(TEST_CONTEXT, C)
+    assert result['success'] is True
+    assert result['did_work'] is False
+
+
+def test_ABC8(run_test):
+    """
+    8.) Run A->B->C,  Run A*->B.   Run A*->B->C, C should re-run
+
+    Args:
+        run_test:
+
+    Returns:
+
+    """
+
+    result = api.apply(TEST_CONTEXT, C)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    B_uuid = api.get(TEST_CONTEXT, 'B').uuid
+
+    def custom_B_requires(self):
+        self.add_dependency('a', APrime, params={})
+
+    old_requires = B.pipe_requires
+    B.pipe_requires = custom_B_requires
+
+    result = api.apply(TEST_CONTEXT, B)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    assert B_uuid != api.get(TEST_CONTEXT, 'B').uuid  # should have a new B
+    B_uuid = api.get(TEST_CONTEXT, 'B').uuid
+    APrime_uuid = api.get(TEST_CONTEXT, 'APrime').uuid
+
+    result = api.apply(TEST_CONTEXT, C)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    assert B_uuid == api.get(TEST_CONTEXT, 'B').uuid
+    assert APrime_uuid == api.get(TEST_CONTEXT, 'APrime').uuid
+
+    B.pipe_requires = old_requires
+
+
+def test_bundle_depsABC9(run_test):
+    """
+    10.) Run A,B -> C(a=A,b=B) Run A,B -> C(a=B,b=A), C should run both times.
+
+    Args:
+        run_test:
+
+    Returns:
+
+    """
+
+    def custom_C_requires(self):
+        self.add_dependency('a', A, params={})
+        self.add_dependency('b', B, params={})
+
+    old_requires = C.pipe_requires
+    C.pipe_requires = custom_C_requires
+
+    result = api.apply(TEST_CONTEXT, C)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    A_uuid = api.get(TEST_CONTEXT, 'A').uuid
+    B_uuid = api.get(TEST_CONTEXT, 'B').uuid
+    C_uuid = api.get(TEST_CONTEXT, 'C').uuid
+
+    def custom_C_requires_swap(self):
+        self.add_dependency('a', B, params={})
+        self.add_dependency('b', A, params={})
+
+    C.pipe_requires = custom_C_requires_swap
+
+    result = api.apply(TEST_CONTEXT, C)
+    assert result['success'] is True
+    assert result['did_work'] is True
+    assert A_uuid == api.get(TEST_CONTEXT, 'A').uuid
+    assert B_uuid == api.get(TEST_CONTEXT, 'B').uuid
+    assert C_uuid != api.get(TEST_CONTEXT, 'C').uuid
+
+    C.pipe_requires = old_requires
+
+
+class A(PipeTask):
+
+    a = luigi.IntParameter(default=1)
+    b = luigi.IntParameter(default=2)
+
+    def pipe_requires(self):
+        pass
+
+    def pipe_run(self):
+        return self.a+self.b
+
+
+class APrime(PipeTask):
+
+    a = luigi.IntParameter(default=2)
+    b = luigi.IntParameter(default=1)
+
+    def pipe_requires(self):
+        pass
+
+    def pipe_run(self):
+        return self.a+self.b
+
+
+class B(PipeTask):
+
+    a = luigi.IntParameter(default=3)
+    b = luigi.IntParameter(default=4)
+
+    def pipe_requires(self):
+        self.add_dependency('a', A, params={})
+
+    def pipe_run(self, a):
+        return a + self.a + self.b
+
+
+class C(PipeTask):
+
+    a = luigi.IntParameter(default=5)
+    b = luigi.IntParameter(default=6)
+
+    def pipe_requires(self):
+        self.add_dependency('b', B, params={})
+
+    def pipe_run(self, **kwargs):
+        input_sum = sum([v for v in kwargs.values()])
+        return input_sum + self.b + self.a
+
+
+if __name__ is '__main__':
+    pytest.main([__file__])


### PR DESCRIPTION
Tasks take both parameters and bundles (requirements) as inputs. 

While parameter changes would cause re-execution, Disdat might re-execute when an upstream bundle (with different parameters) changed.  Run A->B->C,  Run A*->B.   Run A->B->C, and C would re-execute.  However, the version of B that initially ran had no upstreams change and it should not re-run.

To handle this, the processing name now takes into account parameters (md5 hash of params ordered by name) as well as the input bundles (md5 hash of bundle processing_ids ordered by argument name).   This is essentially a Merkle tree.  

Note, we have also changed the output of PipeTask.requires() to be a dictionary of arg_name:task, instead of a list of tasks.    