### PR TITLE
Updated external dependencies to no longer require task class

### DIFF
--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -391,17 +391,17 @@ class DisdatFS(object):
         """
         return self.curr_context and self.curr_context.is_valid()
 
-    def reuse_hframe(self, pipe, hframe, is_left_edge_task, data_context=None):
+    def reuse_hframe(self, pipe, hfr_uuid, is_left_edge_task, data_context=None):
         """
         Re-use this bundle, everything stays the same, just put in the cache
         Note: Currently doesn't use this FS instance, but to be consistent with
         new_output_bundle below.
 
         Args:
-            pipe:
-            hframe:
-            is_left_edge_task:
-            data_context:
+            pipe (`pipe.PipeTask`): The pipe task that should not be re-run.
+            hfr_uuid (str): The UUID of the hyperframe to re-use.
+            is_left_edge_task (bool): Is this at the top of the DAG.
+            data_context: The context containing this bundle with UUID hfr_uuid.
 
         Returns:
             None
@@ -417,8 +417,8 @@ class DisdatFS(object):
         if data_context is None:
             data_context = self.curr_context
 
-        dir = data_context.implicit_hframe_path(hframe.pb.uuid)
-        DisdatFS.put_path_cache(pipe, hframe.pb.uuid, dir, False, is_left_edge_task)
+        dir = data_context.implicit_hframe_path(hfr_uuid)
+        DisdatFS.put_path_cache(pipe, hfr_uuid, dir, False, is_left_edge_task)
 
     def new_output_hframe(self, pipe, is_left_edge_task, force_uuid=None, data_context=None):
         """

--- a/tests/functional/test_external_dep.py
+++ b/tests/functional/test_external_dep.py
@@ -57,7 +57,7 @@ class PipelineB(PipeTask):
         self.set_bundle_name('pipeline_b')
         b = self.add_external_dependency('ext_input',
                                          ExternalPipeline,
-                                         {'test_param': EXT_TASK_PARAM_VAL},
+                                         {},
                                          uuid=self.ext_uuid)
         assert list(b.data) == BUNDLE_CONTENTS
 
@@ -73,7 +73,7 @@ class PipelineC(PipeTask):
         self.set_bundle_name('pipeline_b')
         b = self.add_external_dependency('ext_input',
                                          ExternalPipeline,
-                                         {'test_param': EXT_TASK_PARAM_VAL},
+                                         {},
                                          human_name=self.ext_name)
         assert list(b.data) == BUNDLE_CONTENTS
 


### PR DESCRIPTION
Issue: `pipe.add_external_dependency` used to require a PipeTask class, even when looking up by bundle UUID or bundle human name.   In many cases, the user cannot know the class or may not even have the class present.  

Fix: Introduce a thin ExternalDepTask whose sole parameter is the UUID of the bundle found by add_external_dependency.   When resolving the bundles in `apply.resolve_bundle`, simply re-use that found bundle. 