### PR TITLE
Ensure external dependencies resolve correctly

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -115,8 +115,8 @@ class BundleWrapperTask(PipeTask):
         """ Determine input bundles """
         raise NotImplementedError
 
-    def bundle_outputs(self):
-        """ Determine input bundles """
+    def bundle_output(self):
+        """ Determine output bundle """
         raise NotImplementedError
 
     def human_id(self):

--- a/disdat/pipe_base.py
+++ b/disdat/pipe_base.py
@@ -50,26 +50,25 @@ class PipeBase(object):
         return DisdatFS()
 
     @abstractmethod
-    def bundle_outputs(self):
+    def bundle_output(self):
         """
         Given this pipe, return the set of bundles created by this pipe.
         Mirrors Luigi task.outputs()
 
-        :param pipe_task:  A PipeTask or a DriverTask (both implement PipeBase)
-        :return:  list of bundle names
+        Returns:
+            (processing_name, uuid)
         """
         pass
 
     @abstractmethod
     def bundle_inputs(self):
         """
-
         Given this pipe, return the set of bundles created by the input pipes.
         Mirrors Luigi task.inputs()
 
         :param pipe_task:  A PipeTask or a DriverTask (both implement PipeBase)
-        Returns
-            [(bundle_name, uuid), ... ]
+        Returns:
+            [(processing_name, uuid), ... ]
         """
         pass
 

--- a/tests/functional/test_external_dep.py
+++ b/tests/functional/test_external_dep.py
@@ -113,6 +113,8 @@ def test_uuid_external_dependency(run_test):
     # Ext dep by specific UUID
     api.apply(TEST_CONTEXT, PipelineB, params={'ext_uuid': uuid})
 
+    api.apply(TEST_CONTEXT, PipelineB, params={'ext_uuid': uuid})
+
 
 def test_name_external_dependency(run_test):
 
@@ -125,9 +127,10 @@ def test_name_external_dependency(run_test):
 
 
 if __name__ == '__main__':
-    #api.context(context_name=TEST_CONTEXT)
-    #try:
-    #    test_external_dependency()
-    #finally:
-    #    api.delete_context(context_name=TEST_CONTEXT)
-    pytest.main([__file__])
+    api.context(context_name=TEST_CONTEXT)
+    try:
+        test_uuid_external_dependency(run_test)
+    finally:
+        pass
+        #api.delete_context(context_name=TEST_CONTEXT)
+    #pytest.main([__file__])

--- a/tests/functional/test_external_dep.py
+++ b/tests/functional/test_external_dep.py
@@ -103,6 +103,8 @@ def test_ord_external_dependency(run_test):
     # Ordinary ext dep
     api.apply(TEST_CONTEXT, PipelineA)
 
+    api.apply(TEST_CONTEXT, PipelineA)
+
 
 def test_uuid_external_dependency(run_test):
 
@@ -125,12 +127,14 @@ def test_name_external_dependency(run_test):
     # Ext dep by human name
     api.apply(TEST_CONTEXT, PipelineC, params={'ext_name': EXT_BUNDLE_NAME})
 
+    api.apply(TEST_CONTEXT, PipelineC, params={'ext_name': EXT_BUNDLE_NAME})
+
 
 if __name__ == '__main__':
-    api.context(context_name=TEST_CONTEXT)
-    try:
-        test_uuid_external_dependency(run_test)
-    finally:
-        pass
+    #api.context(context_name=TEST_CONTEXT)
+    #try:
+    #    test_uuid_external_dependency(run_test)
+    #finally:
+    #    pass
         #api.delete_context(context_name=TEST_CONTEXT)
-    #pytest.main([__file__])
+    pytest.main([__file__])


### PR DESCRIPTION
Problem: An external dependency creates a "fake" task in the task graph.  When resolving inputs to the downstream, Disdat must unpack the task to the bundle it refers to. 

Solution: a.) All external dependencies now create ExternalDepTasks.  b.) Ensure that `PipeTask.bundle_inputs` notices and resolves external tasks correctly. 