### PR TITLE
Handle exceptions in PipeTask.requires()

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -16,17 +16,11 @@
 
 
 """
-API
+A Disdat API for creating, publishing, and finding bundles.
 
-A Disdat API for creating and publishing bundles.
-
-These calls are note thread safe.  If they operate on a context, they
+These calls are not thread safe.  If they operate on a context, they
 require the user to specify the context.   This is unlike the CLI that maintains state on disk
-that keeps track of your current context between calls.   The API won't change the context you're in
-in the CLI and vice versa.
-
-To make this work we get a pointer to the singelton FS object, and we temporarily change the context (it will
-automatically assume the context of the CLI) and perform our operation.
+that keeps track of your current context between calls.   The API won't change the CLI's context and vice versa.
 
 Author: Kenneth Yocum
 """

--- a/disdat/api.py
+++ b/disdat/api.py
@@ -235,6 +235,8 @@ class Bundle(HyperFrameRecord):
         self.depends_on = hfr.pb.lineage.depends_on
         self.data = self.data_context.present_hfr(hfr)
 
+        return self
+
     """ Python Context Manager Interface """
 
     def __enter__(self):

--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -279,6 +279,14 @@ class DataContext(object):
         """
         return os.path.join(self._get_local_context_dir(), constants._MANAGED_OBJECTS)
 
+    @staticmethod
+    def s3_remote_from_url(remote_ctxt_url):
+        """ remove '/context' """
+        if remote_ctxt_url is None:
+            return 'None'
+        else:
+            return remote_ctxt_url[:-len('/context')]
+
     def get_remote_object_dir(self):
         """
         Where objects live on remote.

--- a/tests/functional/test_external_dep.py
+++ b/tests/functional/test_external_dep.py
@@ -103,6 +103,8 @@ def test_ord_external_dependency(run_test):
     # Ordinary ext dep
     api.apply(TEST_CONTEXT, PipelineA)
 
+    api.apply(TEST_CONTEXT, PipelineA)
+
 
 def test_uuid_external_dependency(run_test):
 
@@ -125,12 +127,14 @@ def test_name_external_dependency(run_test):
     # Ext dep by human name
     api.apply(TEST_CONTEXT, PipelineC, params={'ext_name': EXT_BUNDLE_NAME})
 
+    api.apply(TEST_CONTEXT, PipelineC, params={'ext_name': EXT_BUNDLE_NAME})
+
 
 if __name__ == '__main__':
-    api.context(context_name=TEST_CONTEXT)
-    try:
-        test_uuid_external_dependency(run_test)
-    finally:
-        pass
+    #api.context(context_name=TEST_CONTEXT)
+    #try:
+    #    test_uuid_external_dependency(run_test)
+    #finally:
+    #    pass
         #api.delete_context(context_name=TEST_CONTEXT)
-    #pytest.main([__file__])
+    pytest.main([__file__])


### PR DESCRIPTION
Background: Luigi's API likes to swallow exceptions, so `disdat.apply` does as well.  However users may still throw exceptions in the requires method.   

Issue: Disdat's `apply` method was not catching the exception, and so it was not correctly cleaning out the path cache, retaining state between successive calls to apply when a prior apply failed.   

Fix: Catch the exception, and clean the pce.  

Extras: 
* Added external dependency tests that poke this issue. 
* Removed the Disdat `status` command 
* Updated the printing of the s3 remote URL so it doesn't append '/context' anymore
* `api.Bundle.fill_from_hfr` now returns `self`
