### PR TITLE
Parallel s3 ls for large object directories

### DIFF
--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -306,10 +306,8 @@ class DataContext(object):
 
     def init_remote_db(self):
         """
-        NOTE: Not sure what this was supposed to do...
-
-        Returns:
-
+        Currently a no-op.  Will connect to something like dynamodb
+        when we have external indices for objects in cloud storage (aka S3).
         """
         pass
 
@@ -511,6 +509,15 @@ class DataContext(object):
         #print "hframes {}".format(hframes)
         #print "frames {}".format(frames)
         #print "auths {}".format(auths)
+
+    def bundle_count(self):
+        """ Determine how many bundles in the current local context
+        Returns:
+            (int): Count of bundles in this local context
+        """
+        assert self.local_engine is not None
+
+        return hyperframe.bundle_count(self.local_engine)
 
     def dbck(self):
         """

--- a/disdat/dsdt.py
+++ b/disdat/dsdt.py
@@ -26,6 +26,7 @@ import argparse
 import logging
 import sys
 import os
+import multiprocessing as mp
 
 from disdat import apply
 from disdat import dockerize
@@ -36,7 +37,6 @@ from disdat.lineage import init_lineage_cl
 from disdat.common import DisdatConfig, load_class
 from disdat import log
 
-
 _pipes_fs = None
 
 DISDAT_PATH = os.environ.get("PATH", None)
@@ -45,10 +45,13 @@ DISDAT_PYTHONPATH = os.environ.get("PYTHONPATH", None)
 
 def main():
     """
-    Main as a function for testing convenience and as a package entry point.
-
-    :return: (shape of input df, shape of pushed df)
+    Main is the package entry point.
     """
+
+    # MacOS X fails when we multi-process using fork and boto sessions.
+    # One fix is to set export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+    # But only in the shell.  To avoid this, we only mp with the forkserver.
+    mp.set_start_method('forkserver')
 
     if getattr(sys, 'frozen', False):
         here = os.path.join(sys._MEIPASS, 'disdat')

--- a/disdat/hyperframe.py
+++ b/disdat/hyperframe.py
@@ -69,7 +69,7 @@ HyperFrameTuple = namedtuple('HyperFrameTuple', 'columns, links, uuid, tags')
 # We can ROLLBACK, ABORT, FAIL, IGNORE, and REPLACE
 # Most cases we want to REPLACE (UPSERT)
 UPSERT_POLICY = 'FAIL'
-
+HFRAMES_TABLE = 'hframes'
 
 class RecordState(enum.Enum):
     """
@@ -324,6 +324,17 @@ def _tag_query(tags):
     return s
 
 
+def bundle_count(engine_g):
+
+    s = text("SELECT count(*) FROM {}".format(HFRAMES_TABLE))
+
+    with engine_g.connect() as conn:
+        result = conn.execute(s)
+        count = result.fetchone()[0]
+
+    return count
+
+
 def select_hfr_db(engine_g, uuid=None, owner=None, human_name=None,
                   processing_name=None, tags=None, state=None,
                   orderby=False, groupby=False, maxbydate=False,
@@ -388,7 +399,7 @@ def select_hfr_db(engine_g, uuid=None, owner=None, human_name=None,
 
     with engine_g.connect() as conn:
         result = conn.execute(s)
-        hfrs = pb_cls.from_row(result) # returns rows if no pb in rows
+        hfrs = pb_cls.from_row(result)  # returns rows if no pb in rows
 
     return hfrs
 
@@ -798,7 +809,7 @@ class HyperFrameRecord(PBObject):
     This is the in-python representation.   Each can import / export to PBs and DBs (via named tuples)
     """
 
-    table_name = 'hframes'
+    table_name = HFRAMES_TABLE
 
     def __init__(self, owner='', human_name='', processing_name='', uuid='',
                  frames=None, lin_obj=None, tags=None, presentation=hyperframe_pb2.DEFAULT):


### PR DESCRIPTION
1.) If number of objects in local directory > 4000, use MP to list s3 directory.
2.) Use MP fork server to avoid process fork safety issues. 