### PR TITLE
fix dsdt pull <bundlename>

### DIFF
--- a/disdat/common.py
+++ b/disdat/common.py
@@ -23,6 +23,7 @@ import sys
 import shutil
 import importlib
 import subprocess
+import multiprocessing as mp
 
 import luigi
 from six.moves import urllib
@@ -130,6 +131,13 @@ class DisdatConfig(object):
             meta_dir_root (str): Optional place to store disdat contexts. Default `~/`
             config_dir (str): Optional directory from which to get disdat.cfg and luigi.cfg.  Default SYSTEM_CONFIG_DIR
         """
+
+        # MacOS X fails when we multi-process using fork and boto sessions.
+        # One fix is to set export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+        # But only in the shell.  To avoid this, we only mp with the forkserver.
+
+        mp.set_start_method('forkserver')
+
         # Find configuration directory
         if config_dir:
             config_dir = config_dir

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -135,7 +135,7 @@ class DisdatConfig(object):
         # MacOS X fails when we multi-process using fork and boto sessions.
         # One fix is to set export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
         # But only in the shell.  To avoid this, we only mp with the forkserver.
-
+        print("SETTING FORKSERVER")
         mp.set_start_method('forkserver')
 
         # Find configuration directory

--- a/disdat/common.py
+++ b/disdat/common.py
@@ -23,7 +23,6 @@ import sys
 import shutil
 import importlib
 import subprocess
-import multiprocessing as mp
 
 import luigi
 from six.moves import urllib
@@ -131,12 +130,6 @@ class DisdatConfig(object):
             meta_dir_root (str): Optional place to store disdat contexts. Default `~/`
             config_dir (str): Optional directory from which to get disdat.cfg and luigi.cfg.  Default SYSTEM_CONFIG_DIR
         """
-
-        # MacOS X fails when we multi-process using fork and boto sessions.
-        # One fix is to set export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
-        # But only in the shell.  To avoid this, we only mp with the forkserver.
-        print("SETTING FORKSERVER")
-        mp.set_start_method('forkserver')
 
         # Find configuration directory
         if config_dir:

--- a/disdat/dsdt.py
+++ b/disdat/dsdt.py
@@ -26,7 +26,6 @@ import argparse
 import logging
 import sys
 import os
-import multiprocessing as mp
 
 from disdat import apply
 from disdat import dockerize
@@ -47,11 +46,6 @@ def main():
     """
     Main is the package entry point.
     """
-
-    # MacOS X fails when we multi-process using fork and boto sessions.
-    # One fix is to set export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
-    # But only in the shell.  To avoid this, we only mp with the forkserver.
-    mp.set_start_method('forkserver')
 
     if getattr(sys, 'frozen', False):
         here = os.path.join(sys._MEIPASS, 'disdat')

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1218,9 +1218,9 @@ class DisdatFS(object):
             if not os.path.exists(local_object_path):
                 fetch_count += 1
                 fetch_tuples.append((s3_bucket, s3_key, local_object_path))
-        _logger.info("Fast pull fetching [{}] objects...".format(fetch_count))
+        _logger.info("Fast pull fetching {} objects...".format(fetch_count))
         results = aws_s3.get_s3_key_many(fetch_tuples)
-        _logger.info("Fast pull completed [{}] transfers -- process pool closed and joined.".format(len(results)))
+        _logger.info("Fast pull completed {} transfers -- process pool closed and joined.".format(len(results)))
 
     def pull(self, human_name=None, uuid=None, localize=False, data_context=None):
         """

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1320,7 +1320,6 @@ class DisdatFS(object):
 
                 # grab frames for this hyperframe
                 s3_hfr_dir = os.path.join(data_context.get_remote_object_dir(), s3_uuid)
-                print(s3_hfr_dir)
                 possible_frame_objects = aws_s3.ls_s3_url_objects(s3_hfr_dir)
                 frame_objects = [obj for obj in possible_frame_objects if '_frame.pb' in obj.key]
                 for s3_fr_obj in frame_objects:

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1208,8 +1208,8 @@ class DisdatFS(object):
 
         remote_s3_object_dir = data_context.get_remote_object_dir()
         s3_bucket, remote_obj_dir = aws_s3.split_s3_url(remote_s3_object_dir)
-        all_keys = aws_s3.ls_s3_url_objects(remote_s3_object_dir,
-                                               is_object_directory=data_context.bundle_count() > aws_s3.S3_LS_USE_MP_THRESH)
+        all_keys = aws_s3.ls_s3_url_keys(remote_s3_object_dir,
+                                         is_object_directory=data_context.bundle_count() > aws_s3.S3_LS_USE_MP_THRESH)
 
         if not localize:
             all_keys = [k for k in all_keys if 'frame.pb' in k]
@@ -1268,7 +1268,6 @@ class DisdatFS(object):
 
         if human_name is None and uuid is None:
             # NOTE: This is fast and loose.  Another command might be editing the db.  Unit test.
-            # NOTE: If we fail, we could have a partial DB.  Need to surface the rebuild command.
             self.fast_pull(data_context, localize)
             data_context.rebuild_db()
             return
@@ -1282,13 +1281,13 @@ class DisdatFS(object):
                 return
             # else fall through to see if we can pull from remote context
 
-        possible_hframe_objects = aws_s3.ls_s3_url_objects(data_context.get_remote_object_dir(),
-                                                           is_object_directory=data_context.bundle_count() > aws_s3.S3_LS_USE_MP_THRESH)
+        possible_hframe_objects = aws_s3.ls_s3_url_keys(data_context.get_remote_object_dir(),
+                                                        is_object_directory=data_context.bundle_count() > aws_s3.S3_LS_USE_MP_THRESH)
 
-        hframe_objects = [obj for obj in possible_hframe_objects if '_hframe.pb' in obj.key]
+        hframe_keys = [obj for obj in possible_hframe_objects if '_hframe.pb' in obj]
 
-        for s3_hfr_obj in hframe_objects:
-            hfr_basename = os.path.basename(s3_hfr_obj.key)
+        for s3_hfr_key in hframe_keys:
+            hfr_basename = os.path.basename(s3_hfr_key)
             # Note that this works because the UUID is prepended to the <uuid>_hframe.pb
             s3_uuid = hfr_basename.split('_')[0]
 
@@ -1303,22 +1302,18 @@ class DisdatFS(object):
                 if not localize:
                     print("Found HyperFrame UUID {} present in local context, skipping . . .".format(s3_uuid))
                 else:
-                    # Are we trying to localize a particular HyperFrame?  match name and uuid. 
-
-                    obj = s3_hfr_obj.Object().get()
-                    hfr_test = hyperframe.HyperFrameRecord.from_str_bytes(obj['Body'].read())
                     if human_name is not None:
-                        if human_name != hfr_test.pb.human_name:
+                        if human_name != local_hfr.pb.human_name:
                             continue
                         else:
-                            print("Found remote bundle with human name {}, uuid {} localizing ...".format(hfr_test.pb.human_name,
-                                                                                                          hfr_test.pb.uuid))
-
-                    # grab files for this hyperframe -- read the local HFR frames
+                            print("Found remote bundle with human name {}, uuid {} localizing ...".format(local_hfr.pb.human_name,
+                                                                                                          local_hfr.pb.uuid))
                     DisdatFS._localize_hfr(local_hfr, s3_uuid, data_context)
-
             else:
-                obj = s3_hfr_obj.Object().get()
+                s3_bucket, _ = aws_s3.split_s3_url(data_context.remote_ctxt_url)
+                found_objects = aws_s3.s3_list_objects_at_prefix(s3_bucket, s3_hfr_key)
+                assert len(found_objects) == 1
+                obj = found_objects[0].Object().get()
                 hfr_test = hyperframe.HyperFrameRecord.from_str_bytes(obj['Body'].read())
                 if human_name is not None:
                     if human_name != hfr_test.pb.human_name:
@@ -1341,11 +1336,12 @@ class DisdatFS(object):
 
                 # grab frames for this hyperframe
                 s3_hfr_dir = os.path.join(data_context.get_remote_object_dir(), s3_uuid)
+                print(s3_hfr_dir)
                 possible_frame_objects = aws_s3.ls_s3_url_objects(s3_hfr_dir)
                 frame_objects = [obj for obj in possible_frame_objects if '_frame.pb' in obj.key]
                 for s3_fr_obj in frame_objects:
                     fr_basename = os.path.basename(s3_fr_obj.key)
-                    local_fr_path = os.path.join(local_uuid_dir,fr_basename)
+                    local_fr_path = os.path.join(local_uuid_dir, fr_basename)
                     s3_fr_obj.Object().download_file(local_fr_path)
 
                 data_context.write_hframe_db_only(hfr_test)

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -30,7 +30,7 @@ from datetime import datetime
 from enum import Enum
 import shutil
 import collections
-from multiprocessing import Pool, cpu_count
+from multiprocessing import get_context
 import subprocess
 import six
 
@@ -1201,7 +1201,10 @@ class DisdatFS(object):
         """
         MAX_WAIT = 12 * 60
 
-        pool = Pool(processes=cpu_count())
+        # MacOS X fails when we multi-process using fork and boto sessions.
+        # One fix is to set export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+        mp_ctxt = get_context('forkserver')
+        pool = mp_ctxt.Pool(processes=mp_ctxt.cpu_count())
 
         _logger.info("Fast Pull synchronizing with remote context {}@{}".format(data_context.remote_ctxt,
                                                                                    data_context.remote_ctxt_url))

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -309,7 +309,7 @@ def s3_list_objects_at_prefix(bucket, prefix):
     try:
         s3_b = s3.Bucket(bucket)
         for i in s3_b.objects.filter(Prefix=prefix, MaxKeys=1024):
-            result.append(i.key)
+            result.append(i)
     except Exception as e:
         _logger.error("s3_list_objects_starting_hex: failed with exception {}".format(e))
         raise
@@ -345,9 +345,9 @@ def s3_list_objects_at_prefix_v2(bucket, prefix):
     return result
 
 
-def ls_s3_url_objects(s3_url, is_object_directory=False):
+def ls_s3_url_keys(s3_url, is_object_directory=False):
     """
-    List all objects at this s3_url.  If `is_object_directory` is True, then
+    List all keys at this s3_url.  If `is_object_directory` is True, then
     treat this `s3_url` as a Disdat object directory, consisting of uuids that start
     with one of 16 ascii characters.  This allows the ls operation to run in parallel.
 
@@ -386,6 +386,29 @@ def ls_s3_url_objects(s3_url, is_object_directory=False):
         results = s3_list_objects_at_prefix_v2(bucket, s3_path)
 
     return results
+
+
+def ls_s3_url_objects(s3_url):
+    """
+    List all objects under this s3_url.
+
+    Note: If you want to get a specific boto s3 object for a key, use s3_list_objects_at_prefix directly.
+
+    Note: the objects returned from this call cannot be subsequently passed into python multiprocessing
+    because they cannot be serialized by default.
+
+    Args:
+        s3_url(str): The bucket and key of the "directory" under which to search
+
+    Returns:
+        list (str): list of s3 objects under the bucket in the s3_path
+    """
+    if s3_url[-1] is not '/':
+        s3_url += '/'
+
+    bucket, s3_path = split_s3_url(s3_url)
+
+    return s3_list_objects_at_prefix(bucket, s3_path)
 
 
 def ls_s3_url(s3_url):

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -26,7 +26,7 @@ import os
 import pkg_resources
 from getpass import getuser
 import six
-from multiprocessing import Pool, cpu_count
+from multiprocessing import get_context
 
 from botocore.exceptions import ClientError
 import boto3 as b3
@@ -369,7 +369,11 @@ def ls_s3_url_keys(s3_url, is_object_directory=False):
 
     MAX_WAIT = 12 * 60
     multiple_results = []
-    pool = Pool(processes=cpu_count()) # I/O bound, so let it use at least cpu_count()
+
+    # MacOS X fails when we multi-process using fork and boto sessions.
+    # One fix is to set export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+    mp_ctxt = get_context('forkserver')
+    pool = mp_ctxt.Pool(processes=mp_ctxt.cpu_count()) # I/O bound, so let it use at least cpu_count()
 
     prefixes = ['']
     if is_object_directory:
@@ -529,9 +533,11 @@ def get_s3_key(bucket, key, filename=None):
     Returns:
 
     """
-    import multiprocessing
-
-    # print ("PID({}) START bkt[] key[{}] file[{}]".format(multiprocessing.current_process(), bucket, key,filename))
+    #import multiprocessing
+    #print ("PID() START bkt[{}] key[{}] file[{}]".format(#multiprocessing.current_process(),
+    #                                                       bucket,
+    #                                                       key,
+    #                                                       filename))
 
     dl_retry = 3
 

--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
             'mock',
             'nose',
             'pylint',
-            'coverage',
+            'coverage==5.1',
             'tox',
             'moto'
         ],


### PR DESCRIPTION
Issue: `dsdt pull` by bundle name was failing b/c the code wasn't updated to deal with string keys being returned from our s3 utilities.   

Fix: update pull() in fs.py module so that we ask for boto s3 objects when we need to. 