### PR TITLE
0.9.0 updates 

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -344,6 +344,7 @@ class Bundle(HyperFrameRecord):
         assert isinstance(params, dict)
         params = {f'{common.BUNDLE_TAG_PARAMS_PREFIX}{k}': v for k, v in params.items()}
         super(Bundle, self).add_tags(params)
+        return self
 
     def add_dependencies(self, bundles, arg_names=None):
         """ Add one or more upstream bundles as dependencies
@@ -462,7 +463,6 @@ class Bundle(HyperFrameRecord):
         self.pb = hfr.pb
         self.init_internal_state()
         self._data = self.data_context.present_hfr(hfr)
-
         return self
 
     """ Python Context Manager Interface """

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -604,7 +604,7 @@ def get_s3_key_many(bucket_key_file_tuples):
 
     """
     MAX_WAIT = 12 * 60
-    mp_ctxt = get_context('fork')  # Using forkserver here causes moto / pytest failures
+    mp_ctxt = get_context('forkserver')  # Using forkserver here causes moto / pytest failures
     pool = mp_ctxt.Pool(processes=mp_ctxt.cpu_count())
     multiple_results = []
     for s3_bucket, s3_key, local_object_path in bucket_key_file_tuples:

--- a/setup.py
+++ b/setup.py
@@ -97,15 +97,15 @@ setup(
     # If <= means higher versions broke something.
 
     install_requires=[
-        'luigi==2.8.11',
-        'boto3==1.13.10', 
-        'termcolor==1.1.0',
-        'docker==4.1.0',
-        'pandas==0.25.3',
-        'numpy==1.18.1',
-        'sqlalchemy==1.3.13',
-        'protobuf==3.11.2',
-        'six==1.13.0',
+        'luigi>=2.8.11,<3.0',
+        'boto3>=1.13.10,<2.0',
+        'termcolor>=1.1.0,<2.0',
+        'docker>=4.1.0,<4.4.0',
+        'pandas>=0.25.3,<=1.0.3',
+        'numpy>=1.18.1,<1.19',
+        'sqlalchemy>=1.3.13,<1.4',
+        'protobuf>=3.11.2,<4.0',
+        'six>=1.13.0,<=1.15',
         'docutils<0.16,>=0.10'
     ],
 
@@ -119,13 +119,13 @@ setup(
             'tensorflow',
         ],
         'dev': [
-            'pytest==5.4.1',
+            'pytest',
             'ipython',
             'mock',
             'nose',
             'pylint',
-            'coverage==5.0.3',
-            'tox==3.14.6',
+            'coverage',
+            'tox',
             'moto'
         ],
         'rel': [

--- a/tox.ini
+++ b/tox.ini
@@ -4,18 +4,23 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37
+envlist = clean,py37
 skip_missing_interpreters=true
 
 [testenv]
 deps =
-    pytest==5.4.1
+    pytest
     pytest-cov
     moto
-    coverage==5.0.3
+    coverage
     pyarrow
     s3fs
 passenv = HOME
 commands =
-    pytest tests/functional #--cov-append --cov=disdat --cov-report html
-    pytest tests/bundles #--cov-append --cov=disdat --cov-report html
+    pytest tests/functional --cov-append --cov=disdat --cov-report html
+    pytest tests/bundles --cov-append --cov=disdat --cov-report html
+
+[testenv:clean]
+deps = coverage
+skip_install = true
+commands = coverage erase


### PR DESCRIPTION
1.) Need to use mp context with 'forkserver' in aws_s3.py, to avoid need for ODBC env var in OS X
2.) Update dependencies from strict '==' to ranges to be a better library.  Moves many packages forward, including numpy and pandas.  
3.) A call in the bundle object in the disdat.api forgot to return self.   
4.) tox coverage was broken, now fixed / addressed with clean target in 'tox.ini'