### PR TITLE
Address empty current context and incremental user package builds

### DIFF
--- a/disdat/add.py
+++ b/disdat/add.py
@@ -47,7 +47,7 @@ def _add(args):
     return
 
 
-def init_add_cl(subparsers):
+def add_arg_parser(subparsers):
     """Initialize a command line set of subparsers with the add command.
 
     Args:

--- a/disdat/api.py
+++ b/disdat/api.py
@@ -790,7 +790,7 @@ def delete_context(context_name, remote=False, force=False):
         None
     """
     fs = _get_fs()
-    fs.delete_branch(context_name, remote=remote, force=force)
+    fs.delete_context(context_name, remote=remote, force=force)
 
 
 def switch(context_name):

--- a/disdat/api.py
+++ b/disdat/api.py
@@ -514,6 +514,7 @@ class Bundle(HyperFrameRecord):
             self.add_frames(frames)
             self.pb.presentation = presentation
             assert self.uuid != '', "Disdat API Error: Cannot close a bundle without a UUID."
+            self.pb.lineage.hframe_uuid = self.uuid
             if self.name == '':
                 if self.code_ref != '':
                     self.name = extract_human_name(self.code_ref)

--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -28,6 +28,7 @@ from __future__ import print_function
 import sys
 import collections
 import os
+import argparse
 
 from luigi import build, worker
 
@@ -537,3 +538,32 @@ def cli_apply(args):
 
     # If we didn't successfully run any task, sys.exit with non-zero code
     common.apply_handle_result(result)
+
+
+def add_arg_parser(subparsers):
+    """Initialize a command line set of subparsers with file system commands.
+
+    Args:
+        subparsers: A collection of subparsers as defined by `argsparse`.
+    """
+
+    apply_p = subparsers.add_parser('apply', description="Apply a transform to an input bundle to produce an output bundle.")
+    apply_p.add_argument('-cs', '--central-scheduler', action='store_true', default=False, help="Use a central Luigi scheduler (defaults to local scheduler)")
+    apply_p.add_argument('-w', '--workers', type=int, default=1, help="Number of Luigi workers on this node")
+    apply_p.add_argument('-it', '--input-tag', nargs=1, type=str, action='append',
+                         help="Input bundle tags: '-it authoritative:True -it version:0.7.1'")
+    apply_p.add_argument('-ot', '--output-tag', nargs=1, type=str, action='append',
+                         help="Output bundle tags: '-ot authoritative:True -ot version:0.7.1'")
+    apply_p.add_argument('-o', '--output-bundle', type=str, default='-',
+                         help="Name output bundle: '-o my.output.bundle'.  Default name is '<TaskName>_<param_hash>'")
+    apply_p.add_argument('-f', '--force', action='store_true', help="Force re-computation of only this task.")
+    apply_p.add_argument('--force-all', action='store_true', help="Force re-computation of ALL upstream tasks.")
+    apply_p.add_argument('--incremental-push', action='store_true', help="Commit and push each task's bundle as it is produced to the remote.")
+    apply_p.add_argument('--incremental-pull', action='store_true', help="Localize bundles as they are needed by downstream tasks from the remote.")
+    apply_p.add_argument('pipe_cls', type=common.load_class, help="User-defined transform, e.g., 'module.PipeClass'")
+    apply_p.add_argument('params', type=str,  nargs=argparse.REMAINDER,
+                         help="Optional set of parameters for this pipe '--parameter value'")
+    apply_p.set_defaults(func=lambda args: cli_apply(args))
+
+
+

--- a/disdat/apply.py
+++ b/disdat/apply.py
@@ -310,7 +310,6 @@ def resolve_bundle(pipe, data_context):
         if verbose: print("resolve_bundle: found ExternalDepTask re-using bundle with UUID[{}].\n".format(pipe.uuid))
         b = api.get(data_context.get_local_name(), None, uuid=pipe.uuid)  # TODO:cache b in ext dep object, no 2x lookup
         if b is None:
-            _logger.warn(f"Unable to resolve bundle[{pipe.uuid}] in context[{data_context.get_local_name()}]")
             reuse_bundle(pipe, b, pipe.uuid, data_context)  # Ensure that the PCE results in a file that cannot be found
         else:
             reuse_bundle(pipe, b, b.uuid, data_context)

--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -110,7 +110,7 @@ class DataContext(object):
         else:
             os.makedirs(local_ctxt_dir)
 
-    def delete_branch(self, force=False):
+    def delete_context(self, force=False):
         """
         Any checks on the local context before we delete all the objects in here?
 

--- a/disdat/infrastructure/dockerizer/Makefile
+++ b/disdat/infrastructure/dockerizer/Makefile
@@ -187,7 +187,11 @@ $(DISDAT_DOCKER_CONTEXT)/disdat: $(DISDAT_DOCKER_CONTEXT) $(shell find $(DISDAT_
 $(DISDAT_DOCKER_CONTEXT)/pipeline: $(DISDAT_DOCKER_CONTEXT) $(shell find $(PIPELINE_ROOT) -not -path '*/\.*' -type f)
 	@echo "----- Copying pipeline $(PIPELINE_ROOT)"
 	cd $(PIPELINE_ROOT); \
-	    python setup.py sdist --dist-dir $@; cd -
+	    mkdir $@; \
+	    python setup.py egg_info; \
+	    cp `ls *.egg-info/requires.txt` $@/user_package_egg_requires.txt; \
+	    python setup.py sdist --dist-dir $@; \
+	    cd -
 	@touch $@
 
 

--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
@@ -68,7 +68,7 @@ fi
 # Second, we install the sdist *.tar.gz.  B/c sdists change on each create, that's installed every time.
 ARG PIPELINE_ROOT
 COPY pipeline/user_package_egg_requires.txt $PIPELINE_ROOT/
-RUN pip install `grep -v '^\[' $PIPELINE_ROOT/user_package_egg_requires.txt`
+RUN pip install `sed -n '1,/\[.*\]/p' $PIPELINE_ROOT/user_package_egg_requires.txt | grep -v '\[' | awk 'NF'`
 
 COPY pipeline $PIPELINE_ROOT
 RUN pip install --no-cache-dir $PIPELINE_ROOT/*.tar.gz

--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
@@ -29,6 +29,7 @@ fi
 RUN files=$(echo $BUILD_ROOT/config/$OS_NAME/*.deb); if [ "$files" != $BUILD_ROOT/config/$OS_NAME/'*.deb' ]; then \
 	for i in $files; do echo "Installing $i..."; dpkg -i $i; apt-get install -y -f;  done; \
 fi
+
 # Install R and packages
 RUN if [ -f $BUILD_ROOT/config/$OS_NAME/r.txt ]; then \
     apt-get update -y \
@@ -50,14 +51,6 @@ RUN if [ -f $BUILD_ROOT/config/$OS_NAME/r.txt ]; then \
 	done; \
 fi
 
-# NOTE: We were installing gdebi in the slim.dockerfile.  It includes an enormous number of dependencies.
-# We can't use autoremove, since it removes more than we installed.   The below is one way to
-# use gdebi, only installing if they have actual .deb files to install.
-#	apt-get install -y gdebi; \
-#	for i in $files; do echo "Installing $i..."; gdebi -n $i; done; \
-#	apt-get -y purge gdebi; \
-
-
 # Install user Python sdist package dependencies
 # NOTE: Since PIP 19.0 fails with --no-cache-dir, removed '-n' flag on kickstart-python.py script
 RUN files=$(echo $BUILD_ROOT/config/python-sdist/*.tar.gz); if [ "$files" != $BUILD_ROOT/config/python-sdist/'*.tar.gz' ]; then \
@@ -67,17 +60,18 @@ RUN files=$(echo $BUILD_ROOT/config/python-sdist/*.tar.gz); if [ "$files" != $BU
 	done; \
 fi
 
-# Install the pipeline package. The user must have a valid setup.py that can generate an sdist .tar.gz.
-# That will have been copied into the docker context.  Note, the install-python-package-from-source-tree script
-# installs with '--no-cache-dir' option.
+# NOTE: 01-disdat-python.dockerfile has set the PATH using ENV, so $VIRTUAL_ENV is already activated.
+
+# Install the user's package.   Split into two parts: package dependencies and user code.
+# First, the Makefile creates egginfo, to create a requires.txt file, and copies into context
+# We only issue the COPY for that file.  This will invalidate the docker layer cache if the requires.txt changes.
+# Second, we install the sdist *.tar.gz.  B/c sdists change on each create, that's installed every time.
 ARG PIPELINE_ROOT
+COPY pipeline/user_package_egg_requires.txt $PIPELINE_ROOT/
+RUN pip install `grep -v '^\[' $PIPELINE_ROOT/user_package_egg_requires.txt`
+
 COPY pipeline $PIPELINE_ROOT
-RUN files=$(echo $PIPELINE_ROOT/*.tar.gz);  if [ "$files" != $PIPELINE_ROOT/'*.tar.gz' ]; then \
-	for i in $files; do \
-	    echo $i; \
-    	$KICKSTART_ROOT/bin/install-python-package-from-source-tree.sh $VIRTUAL_ENV $i; \
-    done; \
-fi
+RUN pip install --no-cache-dir $PIPELINE_ROOT/*.tar.gz
 
 # Set the git status env variables for the container. This represents the most recent git hash for the pipeline.
 ARG GIT_HASH

--- a/disdat/infrastructure/dockerizer/context.template/kickstart/bin/install-python-package-from-source-tree.sh
+++ b/disdat/infrastructure/dockerizer/context.template/kickstart/bin/install-python-package-from-source-tree.sh
@@ -96,9 +96,10 @@ if [ -f $package_root/setup.py ]; then
 	cd $package_root
 	run python setup.py install
 else
-    echo "pip install $package_root"
+  echo "pip install $package_root"
 	pip install --no-cache-dir $package_root
 fi
+
 success "Successfully installed $(basename $package_root) in $virtual_env"
 if [ x$use_conda != 'x' ]; then
 	success "'source $virtual_env/bin/activate $virtual_env' to start using it"

--- a/disdat/lineage.py
+++ b/disdat/lineage.py
@@ -102,7 +102,7 @@ def _lineage(**kwargs):
     return
 
 
-def init_lineage_cl(subparsers):
+def add_arg_parser(subparsers):
     """Initialize a command line set of subparsers with the lineage command.
 
     Args:

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -36,6 +36,9 @@ from disdat import logger as _logger
 
 S3_LS_USE_MP_THRESH = 4000  # the threshold after which we should use MP to look up bundles on s3
 
+MP_CONTEXT_TYPE = 'forkserver'  # Use for published version
+# MP_CONTEXT_TYPE = 'fork'        # Use for testing
+
 
 def batch_get_job_definition_name(pipeline_image_name):
     """Get the most recent active AWS Batch job definition for a dockerized
@@ -375,7 +378,7 @@ def ls_s3_url_keys(s3_url, is_object_directory=False):
 
     # MacOS X fails when we multi-process using fork and boto sessions.
     # One fix is to set export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
-    mp_ctxt = get_context('forkserver')
+    mp_ctxt = get_context(MP_CONTEXT_TYPE)
     pool = mp_ctxt.Pool(processes=mp_ctxt.cpu_count()) # I/O bound, so let it use at least cpu_count()
 
     prefixes = ['']
@@ -463,7 +466,7 @@ def delete_s3_dir_many(s3_urls):
 
     """
     MAX_WAIT = 12 * 60
-    mp_ctxt = get_context('forkserver')  # Using forkserver here causes moto / pytest failures
+    mp_ctxt = get_context(MP_CONTEXT_TYPE)  # Using forkserver here causes moto / pytest failures
     pool = mp_ctxt.Pool(processes=mp_ctxt.cpu_count())
     multiple_results = []
     for s3_url in s3_urls:
@@ -604,7 +607,7 @@ def get_s3_key_many(bucket_key_file_tuples):
 
     """
     MAX_WAIT = 12 * 60
-    mp_ctxt = get_context('forkserver')  # Using forkserver here causes moto / pytest failures
+    mp_ctxt = get_context(MP_CONTEXT_TYPE)  # Using forkserver here causes moto / pytest failures
     pool = mp_ctxt.Pool(processes=mp_ctxt.cpu_count())
     multiple_results = []
     for s3_bucket, s3_key, local_object_path in bucket_key_file_tuples:


### PR DESCRIPTION
Issue:  Disdat may report errors when the user deletes a context that is the current one.   Or tries commands when there is no current context.
Fix:  Added some error handling around this issue in fs.py

Issue: Disdat dockerizer would always re-install all of a user's package's dependencies.  
Fix: Update dockerizer to first install the egg requires.txt, and then install the users package. 