### PR TITLE
Exchange uuid1 for uuid4

### DIFF
--- a/disdat/common.py
+++ b/disdat/common.py
@@ -23,6 +23,7 @@ import sys
 import shutil
 import importlib
 import subprocess
+import uuid
 
 import luigi
 from six.moves import urllib
@@ -285,6 +286,21 @@ def do_subprocess_with_output(cmd):
         return output
     except subprocess.CalledProcessError as cpe:
         raise
+
+#
+# One place to update all the uuid's made by Disdat
+#
+
+def create_uuid():
+    """
+    Note: We had been using uuid1, but found duplicate uuid's when using multiprocessing
+
+    Returns:
+        str: byte string of the 128bit UUID
+
+    """
+    return str(uuid.uuid4())
+
 
 #
 # Make Docker images names from pipeline class names

--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -462,7 +462,7 @@ class DataContext(object):
                     store[rcd.pb.uuid] = rcd
 
         hframe_count = len(hframes.values())
-        ten_percent = int(hframe_count / 10)
+        ten_percent = max(1, int(hframe_count / 10))
         perc = 0
         for i, hfr in enumerate(hframes.values()):
             if i % ten_percent == 0:
@@ -623,8 +623,9 @@ class DataContext(object):
         except (IOError, os.error) as why:
             _logger.error("Removal of hyperframe directory {} failed with error {}.".format(self.implicit_hframe_path(hfr_uuid), why))
 
-            # Must clean up db if directory removal failed, only delete same record if state marked for removal
+            # Must clean up db if directory removal failed
             hyperframe.delete_hfr_db(self.local_engine, uuid=hfr_uuid, state=hyperframe.RecordState.deleted)
+            hyperframe.delete_fr_db(self.local_engine, hfr_uuid)
 
             return False
 

--- a/disdat/data_context.py
+++ b/disdat/data_context.py
@@ -461,7 +461,14 @@ class DataContext(object):
                     rcd = hyperframe.r_pb_fs(f, rcd_type)
                     store[rcd.pb.uuid] = rcd
 
-        for hfr in hframes.values():
+        hframe_count = len(hframes.values())
+        ten_percent = int(hframe_count / 10)
+        perc = 0
+        for i, hfr in enumerate(hframes.values()):
+            if i % ten_percent == 0:
+                print("Disdat DB rebuild: written {} ({} percent) to db".format(i, perc))
+                perc += 10
+
             if DataContext._validate_hframe(hfr, frames, auths):
                 # looks like a good hyperframe
                 # see if it exists, if it does do not write hframe and assume frames are also present

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1195,7 +1195,13 @@ class DisdatFS(object):
                 return
             # else fall through to see if we can pull from remote context
 
-        possible_hframe_objects = aws_s3.ls_s3_url_keys(data_context.get_remote_object_dir(),
+        # If uuid is supplied, just read objects at that key, not all the objects in the context
+        if uuid is not None:
+            object_directory = os.path.join(data_context.get_remote_object_dir(), uuid)
+        else:
+            object_directory = data_context.get_remote_object_dir()
+
+        possible_hframe_objects = aws_s3.ls_s3_url_keys(object_directory,
                                                         is_object_directory=data_context.bundle_count() > aws_s3.S3_LS_USE_MP_THRESH)
 
         hframe_keys = [obj for obj in possible_hframe_objects if '_hframe.pb' in obj]

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -660,9 +660,8 @@ class DisdatFS(object):
     @staticmethod
     def disdat_uuid():
         """
-        Identical to pythia_uuid()
         """
-        return str(uuid.uuid4())
+        return common.create_uuid()
 
     @staticmethod
     def is_bundle_name(possible_bundle_name):

--- a/tests/bundles/test_hframe.py
+++ b/tests/bundles/test_hframe.py
@@ -20,16 +20,7 @@ def _make_linkauth_records():
     :return: s3 auth record, vertica auth record
     """
     slar = hyperframe.S3LinkAuthRecord('id1234', 'keyabcd', 'tokenX', 'wildprofile')
-    vlar = hyperframe.DBLinkAuthRecord("/Library/Vertica/ODBC/lib/libverticaodbc.dylib",
-                                            "Intuit Vertica Connection",
-                                            "Analytics",
-                                            "pprddaavth-vip.ie.intuit.net",
-                                            "kyocum",
-                                            "something",
-                                            "5433",
-                                            "require",
-                                       "superprofile")
-    return slar, vlar
+    return slar
 
 
 def _make_link_records():
@@ -45,18 +36,7 @@ def _make_link_records():
 
     file_link = hyperframe.FileLinkRecord(fake_hfid, fake_laid, BUNDLE_URI_SCHEME+"Users/someuser/somefile.txt")
     s3_link = hyperframe.S3LinkRecord(fake_hfid, fake_laid, BUNDLE_URI_SCHEME+"ds-bucket/keyone/keytwo/target.sql")
-    db_link = hyperframe.DatabaseLinkRecord(fake_hfid,
-                                            fake_laid,
-                                            "db:///some.database.ep",
-                                            "server_sharkbait",
-                                            "db_somedb",
-                                            "schema_some",
-                                            "table_datatable",
-                                            ['col1', 'col2', 'col3'],
-                                            9999,
-                                            "dsn_default")
-
-    return file_link, s3_link, db_link
+    return file_link, s3_link
 
 
 def _make_lineage_record(hframe_name, hframe_uuid, depends_on=None):
@@ -235,17 +215,15 @@ def test_linkauth_rw_pb():
     :return:
     """
 
-    slar, vlar = _make_linkauth_records()
+    slar = _make_linkauth_records()
 
     """ Write out protocol buffers """
 
     w_pb_fs(testdir, slar)
-    w_pb_fs(testdir, vlar)
 
     """ Read in protocol buffers """
 
     r_pb_fs(os.path.join(testdir, slar.get_filename()), hyperframe.S3LinkAuthRecord)
-    r_pb_fs(os.path.join(testdir, vlar.get_filename()), hyperframe.DBLinkAuthRecord)
 
 
 def test_link_rw_pb():
@@ -254,19 +232,17 @@ def test_link_rw_pb():
     :return:
     """
 
-    file_link, s3_link, db_link = _make_link_records()
+    file_link, s3_link = _make_link_records()
 
     """ Write out protocol buffers """
 
     w_pb_fs(testdir, file_link)
     w_pb_fs(testdir, s3_link)
-    w_pb_fs(testdir, db_link)
 
     """ Read in protocol buffers """
 
     r_pb_fs(os.path.join(testdir, file_link.get_filename()), hyperframe.FileLinkRecord)
     r_pb_fs(os.path.join(testdir, s3_link.get_filename()), hyperframe.S3LinkRecord)
-    r_pb_fs(os.path.join(testdir, db_link.get_filename()), hyperframe.DatabaseLinkRecord)
 
 
 
@@ -327,27 +303,22 @@ def test_linkauth_rw_db():
 
     """ Create some PB records """
 
-    slar, vlar = _make_linkauth_records()
+    slar = _make_linkauth_records()
 
     """ Write out PBs as rows """
 
     slar_hash = w_pb_db(slar, engine_g)
-    vlar_hash = w_pb_db(vlar, engine_g)
 
     """ Read in PBs as rows"""
 
     link_auth_results = r_pb_db(hyperframe.LinkAuthBase, engine_g)
 
     slar_hash2 = None
-    vlar_hash2 = None
     for x in link_auth_results:
         if x.pb.WhichOneof('auth') == 's3_auth':
             slar_hash2 = hashlib.md5(slar.pb.SerializeToString()).hexdigest()
-        if x.pb.WhichOneof('auth') == 'db_auth':
-            vlar_hash2 = hashlib.md5(vlar.pb.SerializeToString()).hexdigest()
 
     assert (slar_hash == slar_hash2)
-    assert (vlar_hash == vlar_hash2)
 
 
 def test_link_rw_db():
@@ -365,13 +336,12 @@ def test_link_rw_db():
 
     """ Create some PB records """
 
-    local_link, s3_link, db_link = _make_link_records()
+    local_link, s3_link = _make_link_records()
 
     """ Write out PBs as rows """
 
     local_hash = w_pb_db(local_link, engine_g)
     s3_hash = w_pb_db(s3_link, engine_g)
-    db_hash = w_pb_db(db_link, engine_g)
 
     """ Read in PBs as rows"""
 
@@ -379,18 +349,15 @@ def test_link_rw_db():
 
     local_hash2 = None
     s3_hash2 = None
-    db_hash2 = None
+
     for x in link_results:
         if x.pb.WhichOneof('link') == 'local':
             local_hash2 = hashlib.md5(local_link.pb.SerializeToString()).hexdigest()
         if x.pb.WhichOneof('link') == 's3':
             s3_hash2 = hashlib.md5(s3_link.pb.SerializeToString()).hexdigest()
-        if x.pb.WhichOneof('link') == 'database':
-            db_hash2 = hashlib.md5(db_link.pb.SerializeToString()).hexdigest()
 
     assert (local_hash == local_hash2)
     assert (s3_hash == s3_hash2)
-    assert (db_hash == db_hash2)
 
 
 


### PR DESCRIPTION
Also, 
1.) Now use max_tasks_per_child when using mp pools to recycle processes
2.) Also use callbacks to append results to list in map_async to prevent buffering all results
3.) Fix bug where on dsdt rm, where if the directory was missing we wouldn't remove the frame from the sqlite frame table
4.) Improve performance when `dsdt pull -u <uuid>` so that we only list objects in that object directory.
5.) removed dead code around db links, and remove it from testing as well
6.) added some default printing for rebuilding local sqlite and for s3 mp calls