### PR TITLE
Address mp issues with docker containers

### DIFF
--- a/disdat/config/disdat/disdat.cfg
+++ b/disdat/config/disdat/disdat.cfg
@@ -20,7 +20,7 @@ ignore_code_version=True
 
 [dockerize]
 os_type = python
-os_version = 3.6.8-slim
+os_version = 3.7.8-slim
 
 # Optional other value for os_version
 # os_version = 2.7.15-slim

--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/00-disdat-python-3.7.8-slim.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/00-disdat-python-3.7.8-slim.dockerfile
@@ -1,0 +1,31 @@
+#
+# Kickstart the Python 2 system environment
+#
+
+FROM python:3.7.8-slim
+
+LABEL \
+	author="Theodore Wong"
+
+# Kickstart shell scripts root
+ARG KICKSTART_ROOT
+ENV KICKSTART_ROOT $KICKSTART_ROOT
+
+RUN apt-get update
+RUN apt-get upgrade -y
+
+# Install git and a minimal Python 2.x toolchain. Disdat uses git to detect
+# changed sources when deciding whether or not to rerun a pipeline.
+# disdat uses pyodbc which requires gcc ,hence 'build-essential'
+# sometimes people need to install .deb files, hence gdebi
+RUN apt-get install -y git build-essential unixodbc-dev
+RUN pip install virtualenv==16.7.9
+
+# Install the kickstart scripts used by later layers
+COPY kickstart $KICKSTART_ROOT
+
+# Declare Miniconda configurable arguments. We only need to save the Python
+# virtual environment path for later stages.
+ARG VIRTUAL_ENV
+ENV VIRTUAL_ENV $VIRTUAL_ENV
+

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -267,7 +267,7 @@ def main(input_args):
         entrypoint = input_args.index('--entrypoint')
         del input_args[entrypoint]
         input_args.insert(0, input_args.pop(entrypoint))
-        return subprocess.run(input_args)
+        return subprocess.run(input_args, capture_output=True, check=True)
     except ValueError:
         # There is no entrypoint override, no worries
         pass

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -267,11 +267,10 @@ def main(input_args):
         entrypoint = input_args.index('--entrypoint')
         del input_args[entrypoint]
         input_args.insert(0, input_args.pop(entrypoint))
-        return subprocess.call(input_args)
+        return subprocess.run(input_args)
     except ValueError:
         # There is no entrypoint override, no worries
         pass
-
 
     parser = argparse.ArgumentParser(
         description=_HELP,

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -95,6 +95,9 @@ def _run_local(cli, pipeline_setup_file, arglist, backend):
 
     environment[common.LOCAL_EXECUTION] = 'True'
 
+    # Todo: Local runs do not yet set resource limits, but when they do, we'll have to set this
+    #environment['DISDAT_CPU_COUNT'] = vcpus
+
     volumes = {}
     aws_config_dir = os.getenv('AWS_CONFIG_DIR', os.path.join(os.environ['HOME'], '.aws'))
     if aws_config_dir is not None and os.path.exists(aws_config_dir):

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -292,7 +292,7 @@ def _run_aws_batch(arglist, fq_repository_name, job_name, pipeline_image_name,
                 {'name': 'AWS_SESSION_TOKEN', 'value': credentials.token}
             ]
 
-    container_overrides['environment'].append({'name': 'DISDAT_CPU_COUNT', 'value': vcpus})
+    container_overrides['environment'].append({'name': 'DISDAT_CPU_COUNT', 'value': str(vcpus)})
 
     job = client.submit_job(jobName=job_name, jobDefinition=job_definition_fqn, jobQueue=job_queue,
                             containerOverrides=container_overrides)

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -292,6 +292,8 @@ def _run_aws_batch(arglist, fq_repository_name, job_name, pipeline_image_name,
                 {'name': 'AWS_SESSION_TOKEN', 'value': credentials.token}
             ]
 
+    container_overrides['environment'].append({'name': 'DISDAT_CPU_COUNT', 'value': vcpus})
+
     job = client.submit_job(jobName=job_name, jobDefinition=job_definition_fqn, jobQueue=job_queue,
                             containerOverrides=container_overrides)
 

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -399,6 +399,7 @@ def ls_s3_url_keys(s3_url, is_object_directory=False):
         pool.close()
         pool.join()
     else:
+        print("ls_s3_url_keys not using MP for this list operation")
         results = s3_list_objects_at_prefix_v2(bucket, s3_path)
 
     return results


### PR DESCRIPTION
1.) use subprocess.run() instead of call() in entrypoint
2.) allow user to override cpu count when executing in a container
3.) use a context manager when working with mp pools