### PR TITLE
removed ENTRYPOINT from docker builds, updated run to account for this

### DIFF
--- a/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
+++ b/disdat/infrastructure/dockerizer/context.template/Dockerfiles/02-user.dockerfile
@@ -91,5 +91,4 @@ RUN rm -rf $BUILD_ROOT
 # Set up the default entry point. If the user starts an image with no
 # arguments, show some help
 COPY bin/entrypoint.py /opt/bin/entrypoint.py
-ENTRYPOINT [ "/opt/bin/entrypoint.py" ]
-CMD [ "--help" ]
+CMD [ "/opt/bin/entrypoint.py", "--help" ]

--- a/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
+++ b/disdat/infrastructure/dockerizer/context.template/bin/entrypoint.py
@@ -262,16 +262,6 @@ def main(input_args):
     # of how you might do this in the future if needed.
     # some_default = os.environ[ENVVAR] if ENVVAR in os.environ else None
 
-    # Skip all the argparse stuff, and first check for --entrypoint
-    try:
-        entrypoint = input_args.index('--entrypoint')
-        del input_args[entrypoint]
-        input_args.insert(0, input_args.pop(entrypoint))
-        return subprocess.run(input_args, capture_output=True, check=True)
-    except ValueError:
-        # There is no entrypoint override, no worries
-        pass
-
     parser = argparse.ArgumentParser(
         description=_HELP,
     )

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -54,6 +54,9 @@ from disdat import logger as _logger
 _MODULE_NAME = inspect.getmodulename(__file__)
 
 
+ENTRYPOINT_BIN = '/opt/bin/entrypoint.py'
+
+
 class Backend(Enum):
     Local = 0
     AWSBatch = 1
@@ -123,7 +126,7 @@ def _run_local(cli, pipeline_setup_file, arglist, backend):
                 _logger.info("VOLUMES: {}".format(volumes))
         else:
             # Add the actual command to the arglist (for non-sagemaker runs)
-            arglist = ['/opt/bin/entrypoint.py'] + arglist
+            arglist = [ENTRYPOINT_BIN] + arglist
             pipeline_image_name = common.make_project_image_name(pipeline_setup_file)
 
         _logger.debug('Running image {} with arguments {}'.format(pipeline_image_name, arglist))
@@ -506,7 +509,7 @@ def _run(
         if backend == Backend.AWSBatch:
 
             # Add the actual command to the arglist
-            arglist = ['/opt/bin/entrypoint.py'] + arglist
+            arglist = [ENTRYPOINT_BIN] + arglist
 
             retval = _run_aws_batch(arglist,
                                     fq_repository_name,

--- a/disdat/run.py
+++ b/disdat/run.py
@@ -122,6 +122,8 @@ def _run_local(cli, pipeline_setup_file, arglist, backend):
                 volumes[localdir] = {'bind': '/opt/ml/input/config/', 'mode': 'rw'}
                 _logger.info("VOLUMES: {}".format(volumes))
         else:
+            # Add the actual command to the arglist (for non-sagemaker runs)
+            arglist = ['/opt/bin/entrypoint.py'] + arglist
             pipeline_image_name = common.make_project_image_name(pipeline_setup_file)
 
         _logger.debug('Running image {} with arguments {}'.format(pipeline_image_name, arglist))
@@ -502,6 +504,9 @@ def _run(
         fq_repository_name = get_fq_docker_repo_name(False, pipeline_setup_file)
 
         if backend == Backend.AWSBatch:
+
+            # Add the actual command to the arglist
+            arglist = ['/opt/bin/entrypoint.py'] + arglist
 
             retval = _run_aws_batch(arglist,
                                     fq_repository_name,


### PR DESCRIPTION
removed ENTRYPOINT from dockerfile so that it can be overwritten directly.
updated run methods to add the hard-coded entrypoint to the beginning of their command
did not make corresponding changes to any sagemaker entrypoints