### PR TITLE
fix delocalize on failed push

### DIFF
--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1138,6 +1138,11 @@ class DisdatFS(object):
                     to_delete.append(urllib.parse.urlparse(src).path)
 
         _logger.info("Fast push copying {} objects to S3 . . .".format(len(push_tuples)))
+        #for s, d in push_tuples:
+        #    _logger.info("----> ".format(push_tuples))
+        #    _logger.info("\tSRC {} ".format(s))
+        #    _logger.info("\tDST {} ".format(d))
+
         results = aws_s3.put_s3_key_many(push_tuples)
         _logger.info("Fast push completed {} transfers -- process pool closed and joined.".format(len(results)))
         assert len(results) == len(push_tuples), "Fast push failed: transferred {} out of {} files".format(len(results),

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1115,7 +1115,7 @@ class DisdatFS(object):
         Returns:
             None
         """
-        _logger.info("Fast Pull synchronizing with remote context {}@{}".format(data_context.remote_ctxt,
+        _logger.info("Fast Push synchronizing with remote context {}@{}".format(data_context.remote_ctxt,
                                                                                 data_context.remote_ctxt_url))
 
         remote_s3_object_dir = data_context.get_remote_object_dir()
@@ -1140,7 +1140,8 @@ class DisdatFS(object):
         _logger.info("Fast push copying {} objects to S3 . . .".format(len(push_tuples)))
         results = aws_s3.put_s3_key_many(push_tuples)
         _logger.info("Fast push completed {} transfers -- process pool closed and joined.".format(len(results)))
-
+        assert len(results) == len(push_tuples), "Fast push failed: transferred {} out of {} files".format(len(results),
+                                                                                                           len(push_tuples))
         if delocalize:
             for f in to_delete:
                 try:

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -589,7 +589,7 @@ def cp_local_to_s3_file(local_file, s3_file):
     s3 = get_s3_resource()
     bucket, s3_path = split_s3_url(s3_file)
     local_file = urllib.parse.urlparse(local_file).path
-    # print("cp s3 src {}  dst {}".format(local_file, s3_file))
+    # print("AWS_S3: ----->>>>>>>\tCP s3 src {}  dst {}".format(local_file, s3_file))
     s3.Object(bucket, s3_path).upload_file(local_file, ExtraArgs={"ServerSideEncryption": "AES256"})
     return s3_file
 


### PR DESCRIPTION
Problem:  If tokens expire during mp push, processes can join without raising error to parent.   We weren't checking the number of files transferred, so the code assumed successful copies of the links.  It then deleted them.
Fix:  Check to make sure the number of asked transfers complete.  If not assert and fail. 