### PR TITLE
Ensure s3 writes have bucket owner control

### DIFF
--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -1360,8 +1360,10 @@ def _commit(fs, args):
 
 
 def _remote(fs, args):
-    fs.remote_add(args.context, args.s3_url)
-
+    try:
+        fs.remote_add(args.context, args.s3_url)
+    except RuntimeError as rte:
+        pass
 
 def _push(fs, args):
     bundle = None

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -571,7 +571,11 @@ def cp_s3_file(s3_src_path, s3_root):
     src_bucket, src_key = split_s3_url(s3_src_path)
     # print "Trying to copy from bucket {} key {} to bucket {} key {}".format(src_bucket, src_key, bucket, output_path)
 
-    s3.Object(bucket, output_path).copy_from(CopySource={'Bucket': src_bucket, 'Key': src_key}, ServerSideEncryption="AES256")
+    s3.Object(bucket, output_path).copy_from(
+        CopySource={'Bucket': src_bucket, 'Key': src_key},
+        ExtraArgs={"ACL": "bucket-owner-full-control"},
+        ServerSideEncryption="AES256"
+    )
     return os.path.join("s3://", bucket, output_path)
 
 
@@ -590,7 +594,10 @@ def cp_local_to_s3_file(local_file, s3_file):
     bucket, s3_path = split_s3_url(s3_file)
     local_file = urllib.parse.urlparse(local_file).path
     # print("AWS_S3: ----->>>>>>>\tCP s3 src {}  dst {}".format(local_file, s3_file))
-    s3.Object(bucket, s3_path).upload_file(local_file, ExtraArgs={"ServerSideEncryption": "AES256"})
+    s3.Object(bucket, s3_path).upload_file(
+        local_file,
+        ExtraArgs={"ServerSideEncryption": "AES256", "ACL": "bucket-owner-full-control"}
+    )
     return s3_file
 
 
@@ -610,7 +617,10 @@ def put_s3_file(local_path, s3_root):
     if s3_path is None:
         s3_path = ''
     filename = os.path.basename(local_path)
-    s3.Object(bucket, os.path.join(s3_path, filename)).upload_file(local_path, ExtraArgs={"ServerSideEncryption": "AES256"})
+    s3.Object(bucket, os.path.join(s3_path, filename)).upload_file(
+        local_path,
+        ExtraArgs={"ServerSideEncryption": "AES256", "ACL": "bucket-owner-full-control"}
+    )
     return os.path.join(s3_root, filename)
 
 

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -36,7 +36,6 @@ from disdat import logger as _logger
 
 S3_LS_USE_MP_THRESH = 4000  # the threshold after which we should use MP to look up bundles on s3
 
-
 # Use forkserver unless this environment variable is set (hopefully to fork, used by testing)
 MP_CONTEXT_TYPE = os.environ.get('MP_CONTEXT_TYPE', 'forkserver')
 MAX_TASKS_PER_CHILD = 100       # Force the pool to kill workers when they've done 100 tasks.
@@ -728,7 +727,7 @@ def get_s3_key_many(bucket_key_file_tuples):
         for s3_bucket, s3_key, local_object_path in bucket_key_file_tuples:
             multiple_results.append(pool.apply_async(get_s3_key,
                                                      (s3_bucket, s3_key, local_object_path),
-                                                     callback=results.extend))
+                                                     callback=results.append))
 
         pool.close()
         pool.join()

--- a/disdat/utility/aws_s3.py
+++ b/disdat/utility/aws_s3.py
@@ -36,8 +36,9 @@ from disdat import logger as _logger
 
 S3_LS_USE_MP_THRESH = 4000  # the threshold after which we should use MP to look up bundles on s3
 
-MP_CONTEXT_TYPE = 'forkserver'  # Use for published version
-#MP_CONTEXT_TYPE = 'fork'       # Use for testing
+
+# Use forkserver unless this environment variable is set (hopefully to fork, used by testing)
+MP_CONTEXT_TYPE = os.environ.get('MP_CONTEXT_TYPE', 'forkserver')
 MAX_TASKS_PER_CHILD = 100       # Force the pool to kill workers when they've done 100 tasks.
 
 
@@ -573,7 +574,7 @@ def cp_s3_file(s3_src_path, s3_root):
 
     s3.Object(bucket, output_path).copy_from(
         CopySource={'Bucket': src_bucket, 'Key': src_key},
-        ExtraArgs={"ACL": "bucket-owner-full-control"},
+        ACL="bucket-owner-full-control",
         ServerSideEncryption="AES256"
     )
     return os.path.join("s3://", bucket, output_path)

--- a/tests/functional/test_add_remote.py
+++ b/tests/functional/test_add_remote.py
@@ -1,0 +1,103 @@
+#
+# Copyright 2017 Human Longevity, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Test add remote
+
+Use the API to add a remote
+
+"""
+import boto3
+import moto
+import pytest
+
+import disdat.api as api
+from tests.functional.common import TEST_CONTEXT
+
+
+TEST_REMOTE = '__test_remote_context__'
+TEST_BUCKET = 'test-bucket'
+TEST_BUCKET_URL = "s3://{}".format(TEST_BUCKET)
+TEST_BUCKET_KEY_URL = "s3://{}/somekey".format(TEST_BUCKET)
+
+
+@moto.mock_s3
+def test_add_remote():
+    api.delete_context(TEST_CONTEXT)
+    api.context(context_name=TEST_CONTEXT)
+
+    # Setup moto s3 resources
+    s3_client = boto3.client('s3')
+    s3_resource = boto3.resource('s3')
+    s3_resource.create_bucket(Bucket=TEST_BUCKET)
+
+    # Make sure bucket is empty
+    objects = s3_client.list_objects(Bucket=TEST_BUCKET)
+    assert 'Contents' not in objects, 'Bucket should be empty'
+
+    # Bind remote context with just bucket
+    api.remote(TEST_CONTEXT, TEST_REMOTE, TEST_BUCKET_URL)
+
+    with api.Bundle(TEST_CONTEXT) as b:
+        b.name = 'output'
+        b.add_data([1, 3, 5])
+
+    b.commit()
+    b.push()
+
+    # Bind remote to new context with bucket and key
+    api.remote(TEST_CONTEXT, TEST_REMOTE, TEST_BUCKET_KEY_URL)
+
+    with api.Bundle(TEST_CONTEXT) as b:
+        b.name = 'output'
+        b.add_data([1, 3, 5])
+
+    b.commit()
+    b.push()
+
+    api.delete_context(TEST_CONTEXT)
+
+
+@moto.mock_s3
+def test_add_remote_fail():
+    error = None
+    api.delete_context(TEST_CONTEXT)
+    api.context(context_name=TEST_CONTEXT)
+
+    # Setup moto s3 resources
+    s3_client = boto3.client('s3')
+    s3_resource = boto3.resource('s3')
+
+    # Bind remote context with just bucket
+    try:
+        api.remote(TEST_CONTEXT, TEST_REMOTE, TEST_BUCKET_URL)
+    except Exception as e:
+        error = e
+    finally:
+        assert(type(error) == RuntimeError)
+
+    # Bind remote to new context with bucket and key
+    try:
+        api.remote(TEST_CONTEXT, TEST_REMOTE, TEST_BUCKET_KEY_URL)
+    except Exception as e:
+        error = e
+    finally:
+        assert(type(error) == RuntimeError)
+
+    api.delete_context(TEST_CONTEXT)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__])

--- a/tests/functional/test_managed.py
+++ b/tests/functional/test_managed.py
@@ -329,8 +329,8 @@ def test_no_remote_no_push_non_managed_s3():
 
 
 if __name__ == '__main__':
-    test_remote_push_managed_s3()
-    #pytest.main([__file__])
+    #test_remote_push_managed_s3()
+    pytest.main([__file__])
 
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,10 @@ deps =
     pyarrow
     s3fs<=0.4.2
 passenv = HOME
+setenv = MP_CONTEXT_TYPE = fork
 commands =
-    pytest tests/functional --cov-append --cov=disdat --cov-report html
-    pytest tests/bundles --cov-append --cov=disdat --cov-report html
+    pytest tests/functional --disable-warnings --cov-append --cov=disdat --cov-report html
+    pytest tests/bundles --disable-warnings --cov-append --cov=disdat --cov-report html
 
 [testenv:clean]
 deps = coverage

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ skip_missing_interpreters=true
 deps =
     pytest
     pytest-cov
-    moto
+    moto==1.3.14
     coverage
     pyarrow
     s3fs<=0.4.2


### PR DESCRIPTION
1.) Ensure s3 writes set up objects with the bucket control policy
2.) Improve `dsdt remote` semantics to allow adding a remote to a key that doesn't exist. 
3.) Convert some print outputs to logger.debug outputs
4.) Fix fast pull feedback on the number of transfers completed. 