### PR TITLE
Improve getting pipe git info, and package versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .tox
 .coverage
 htmlcov
+/disdat/version.py

--- a/disdat/__init__.py
+++ b/disdat/__init__.py
@@ -14,3 +14,6 @@
 # limitations under the License.
 #
 from disdat.log import logger
+from disdat.version import __version__
+
+

--- a/disdat/__init__.py
+++ b/disdat/__init__.py
@@ -14,6 +14,11 @@
 # limitations under the License.
 #
 from disdat.log import logger
-from disdat.version import __version__
+
+try:
+    from disdat.version import __version__
+except ImportError:  # pragma: no cover
+    __version__ = 'dev'
+
 
 

--- a/disdat/entrypoints/cli_ep.py
+++ b/disdat/entrypoints/cli_ep.py
@@ -29,7 +29,7 @@ import os
 
 from disdat import apply, dockerize, run, fs, add, lineage
 from disdat.common import DisdatConfig
-from disdat import log
+from disdat import log, __version__
 
 _pipes_fs = None
 
@@ -46,9 +46,6 @@ def main():
         here = os.path.join(sys._MEIPASS, 'disdat')
     else:
         here = os.path.abspath(os.path.dirname(os.path.dirname(__file__)))
-
-    with open(os.path.join(here, 'VERSION')) as version_file:
-        __version__ = version_file.read().strip()
 
     args = sys.argv[1:]
 

--- a/disdat/entrypoints/docker_ep.py
+++ b/disdat/entrypoints/docker_ep.py
@@ -48,8 +48,8 @@ def _context_and_remote(context_name, remote=None):
     retval = disdat.api.context(context_name)
 
     if retval == 1: # branch exists
-        _logger.warn("Entrypoint found existing local context {} ".format(context_name))
-        _logger.warn("Entrypoint not switching and ignoring directive to change to remote context {}".format(remote))
+        _logger.warning("Entrypoint found existing local context {} ".format(context_name))
+        _logger.warning("Entrypoint not switching and ignoring directive to change to remote context {}".format(remote))
     elif retval == 0: # just made a new branch
         if remote is not None:
             _logger.info("Entrypoint made a new context {}, attaching remote {}".format(context_name, remote))

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -89,7 +89,6 @@ def determine_pipe_version(pipe_root):
     Given a pipe file path, return the repo status. If they are set, use the environment variables,
     otherwise run the git commands.
 
-
     Args:
         pipe_root: path to the root of the pipeline
 
@@ -99,6 +98,13 @@ def determine_pipe_version(pipe_root):
         which haven't been checked in yet.
     """
 
+    def _get_git_info_var(var_name, git_command):
+        thing = os.getenv(var_name)
+        if thing is None:
+            thing = _run_git_cmd(pipe_root, git_command,  get_output=True)
+        thing = _check_type_and_rstrip(thing, "unknown")
+        return thing
+
     def _check_type_and_rstrip(val, default):
         if isinstance(val, six.string_types):
             val = val.rstrip()
@@ -106,23 +112,11 @@ def determine_pipe_version(pipe_root):
             val = default
         return val
 
-    _logger.debug("PIPELINE_GIT_HASH = {}  cli hash = {}".format(os.environ.get('PIPELINE_GIT_HASH'),
-                                                                 _run_git_cmd(pipe_root, 'rev-parse --short HEAD', get_output=True)))
-    _logger.debug("git_branch = {os.environ.get('PIPELINE_GIT_BRANCH')}")
-
-    git_hash = os.getenv('PIPELINE_GIT_HASH', _run_git_cmd(pipe_root, 'rev-parse HEAD',  get_output=True))
-    git_hash = _check_type_and_rstrip(git_hash, "unknown")
-
-    git_branch = os.getenv('PIPELINE_GIT_BRANCH', _run_git_cmd(pipe_root, 'rev-parse --abbrev-ref HEAD',  get_output=True))
-    git_branch = _check_type_and_rstrip(git_branch, "unknown")
-
-    git_fetch_url = os.getenv('PIPELINE_GIT_FETCH_URL', _run_git_cmd(pipe_root, 'config --get remote.origin.url',  get_output=True))
-    git_fetch_url = _check_type_and_rstrip(git_fetch_url, "unknown")
-
-    git_timestamp = os.getenv('PIPELINE_GIT_TIMESTAMP', _run_git_cmd(pipe_root, 'log -1 --pretty=format:%aI',  get_output=True))
-    git_timestamp = _check_type_and_rstrip(git_timestamp, "unknown")
-
-    git_dirty = bool(os.getenv('GIT_DIRTY', _run_git_cmd(pipe_root, 'diff --name-only',  get_output=True)))
+    git_hash = _get_git_info_var('PIPELINE_GIT_HASH', 'rev-parse HEAD')
+    git_branch = _get_git_info_var('PIPELINE_GIT_BRANCH', 'rev-parse --abbrev-ref HEAD')
+    git_fetch_url = _get_git_info_var('PIPELINE_GIT_FETCH_URL', 'config --get remote.origin.url')
+    git_timestamp = _get_git_info_var('PIPELINE_GIT_TIMESTAMP', 'log -1 --pretty=format:%aI')
+    git_dirty = bool(_get_git_info_var('GIT_DIRTY', 'diff --name-only'))
 
     obj_version = CodeVersion(semver="0.1.0", hash=git_hash, tstamp=git_timestamp, branch=git_branch,
                               url=git_fetch_url, dirty=git_dirty)

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -73,7 +73,7 @@ def _run_git_cmd(git_dir, git_cmd, get_output=False):
                 output = subprocess.check_output(cmd, stderr=null_file)
         except subprocess.CalledProcessError as e:
             _logger.debug("Unable to run git command {}: exit {}: likely no git repo, e.g., running in a container.".format(cmd, e.returncode))
-            return e.returncode
+            return None
     else:
         with open(os.devnull, 'w') as null_file:
             output = subprocess.call(cmd, stdout=null_file, stderr=null_file)

--- a/setup.py
+++ b/setup.py
@@ -17,13 +17,6 @@ from setuptools import setup, find_packages
 import os
 
 
-def find_version():
-    here = os.path.abspath(os.path.dirname(__file__))
-    with open(os.path.join(here, 'disdat','VERSION')) as version_file:
-        version = version_file.read().strip()
-    return version
-
-
 setup(
     use_scm_version={
         'write_to': 'disdat/version.py',
@@ -124,7 +117,6 @@ setup(
             'pytest',
             'ipython',
             'mock',
-            'nose',
             'pylint',
             'coverage',
             'tox',

--- a/setup.py
+++ b/setup.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 #
 from setuptools import setup, find_packages
-import os
-
 
 setup(
     use_scm_version={
@@ -25,7 +23,6 @@ setup(
     setup_requires=['setuptools_scm'],
 
     name='disdat',
-    version=find_version(),
     description='DisDat: versioned data science',
     author='Ken Yocum',
     author_email='kyocum@gmail.com',

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,14 @@ def find_version():
         version = version_file.read().strip()
     return version
 
+
 setup(
+    use_scm_version={
+        'write_to': 'disdat/version.py',
+        'write_to_template': '__version__ = "{version}"'
+    },
+    setup_requires=['setuptools_scm'],
+
     name='disdat',
     version=find_version(),
     description='DisDat: versioned data science',


### PR DESCRIPTION
Issue: when running Luigi tasks, we call git to get information about the code.  The user could use env variables.  But we were always calling git even if they were defined.   

Change: Modify `determine_pipe_version` so that it only exec's git if the env vars are not set. 

Also updated to using setuptools_scm for versioning the package. 