### PR TITLE
Allow args to entrypoint without sys.argv

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -44,4 +44,4 @@ jobs:
         echo "Creating sdist with a copy of itself ..."
         python setup.py sdist
         echo "Uploading to PyPi ... (not yet)"
-        # twine upload dist/disdat-*.tar.gz
+        twine upload dist/disdat-*.tar.gz

--- a/disdat/entrypoints/docker_ep.py
+++ b/disdat/entrypoints/docker_ep.py
@@ -253,9 +253,7 @@ def run_disdat_container(args):
     sys.exit(os.EX_OK)
 
 
-def main():
-
-    input_args = sys.argv[1:]
+def argparse_and_run(input_args):
 
     # To simplify configuring and building pipeline images, we can keep
     # various default parameter values in the Docker image makefile,
@@ -376,6 +374,11 @@ def main():
     log.enable(level=log_level)  # TODO: Add configurable verbosity
 
     run_disdat_container(args)
+
+
+def main():
+    input_args = sys.argv[1:]
+    argparse_and_run(input_args)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Added `argparse_and_run(cmd)` so one can use the Disdat entrypoint by making your own command array.
