### PR TITLE
Restrict python version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,8 @@ setup(
 
     data_files=[('', ['setup.py'])],
 
+    python_requires='>=3.7, <3.10',
+
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed.  If >=, means it worked with the base version.
     # If <= means higher versions broke something.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = clean,py37,py38
+envlist = clean,py{37,38,39}
 skip_missing_interpreters=true
 
 [testenv]


### PR DESCRIPTION
Install is unpredictable in python > 3.9 envs.  Restrict what versions are useable. 