### PR TITLE
Add access to `remote_dir` from bundle object

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -276,6 +276,10 @@ class Bundle(HyperFrameRecord):
         return self._local_dir
 
     @property
+    def remote_dir(self):
+        return self._remote_dir
+
+    @property
     def tags(self):
         """Return the tags that the user set
         bundle.tags holds all of the tags, including the "hidden" parameter tags.


### PR DESCRIPTION
Users need to check the remote directory of the bundle's context.  They may create a bundle without a remote and they should be able to check the condition before they call push.   

Here we simply add a property to access the existing field in the bundle.   So now they can access it via 
`Bundle.remote_dir` , just like they already can with `Bundle.local_dir`. 