### PR TITLE
Fix accidental code delete

### DIFF
--- a/disdat/api.py
+++ b/disdat/api.py
@@ -428,7 +428,7 @@ class Bundle(HyperFrameRecord):
         """
         self._check_open()
         curr_count = LineageRecord.dependency_count(self.pb.lineage)
-        if isinstance(bundles, collections.Iterable):
+        if isinstance(bundles, collections.abc.Iterable):
             if arg_names is None:
                 arg_names = [
                     "_arg_{}".format(i)

--- a/disdat/fs.py
+++ b/disdat/fs.py
@@ -84,11 +84,10 @@ def _run_git_cmd(git_dir, git_cmd, get_output=False):
 
     return output
 
-    """
-def determine_pipe_version(pipe_root):
-    Given a pipe file path, return the repo status. If they are set, use the environment variables,
-    otherwise run the git commands.
 
+def determine_pipe_version(pipe_root):
+    """ Given a pipe file path, return the repo status. If they are set, use the environment variables,
+    otherwise run the git commands.
 
     Args:
         pipe_root: path to the root of the pipeline

--- a/tests/functional/test_add.py
+++ b/tests/functional/test_add.py
@@ -17,8 +17,6 @@
 import hashlib
 import os
 
-import boto3
-import moto
 import pandas as pd
 import pytest
 


### PR DESCRIPTION
Issue: Prior commit had accidentally deleted the fs.py:determine_pipe_function function.  
Fix: The accident involved badly placed """.   We fix that. 
In addition:
* updated to use collections.abc
* clean up some other imports