### PR TITLE
Update python

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@
 
 Note: Disdat 1.0 no longer contains the instrumented form of Luigi.  Disdat-Luigi now resides `here <https://github.com/kyocum/disdat-luigi>`_.  Want to build versioned pipelines?  ``pip install disdat-luigi``   Want to just use the Disdat API?   ``pip install disdat`` 
 
-Disdat is a Python (3.6, 3.7, +) package for data versioning that allows data scientists to create, share, and track data products.  Disdat organizes data into *bundles*, collections of literal values and files -- bundles are the unit at which data is versioned and shared.   Disdat provides an *API* for creating, finding, and publishing bundles to cloud storage (e.g., AWS S3).  
+Disdat is a Python (3.9+) package for data versioning that allows data scientists to create, share, and track data products.  Disdat organizes data into *bundles*, collections of literal values and files -- bundles are the unit at which data is versioned and shared.   Disdat provides an *API* for creating, finding, and publishing bundles to cloud storage (e.g., AWS S3).
 
 `Disdat-Luigi  <https://github.com/kyocum/disdat-luigi>`_ uses this API to instrument Spotify's Luigi, so you can build pipelines that automatically create bundles, making it easy to share the latest outputs with other users and pipelines.  Instead of lengthy email conversations with multiple file attachments, searching through Slack for the most recent S3 file path, users can instead ``dsdt pull awesome_data`` to get the latest 'awesome_data.'
 

--- a/setup.py
+++ b/setup.py
@@ -88,7 +88,7 @@ setup(
             "pylint",
             "coverage",
             "tox",
-            "moto==2.2.13",  # same as tox.ini
+            "moto",  # same as tox.ini
             "s3fs<=0.4.2",  # 0.5.0 breaks with aiobotocore and missing AWS headers
         ],
         "rel": [

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
     },
     exclude_package_data={"disdat": []},
     data_files=[("", ["setup.py"])],
-    python_requires=">=3.8, <3.12",
+    python_requires=">=3.9, <3.14",
     # List run-time dependencies here.  These will be installed by pip when
     # your project is installed.  If >=, means it worked with the base version.
     # If <= means higher versions broke something.

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,11 @@ setup(
         "License :: OSI Approved :: Apache Software License",
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Operating System :: OS Independent",
         "Natural Language :: English",
     ],

--- a/tests/bundles/test_file_bundle_api.py
+++ b/tests/bundles/test_file_bundle_api.py
@@ -83,7 +83,7 @@ def test_zero_copy_local_file(run_test):
     assert md5_file(b.data[1]) == saved_f2_md5
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_copy_in_s3_file(run_test):
     """Test copying in s3 file
     The file should be copied into the local context
@@ -110,7 +110,7 @@ def test_copy_in_s3_file(run_test):
     assert md5 == saved_md5
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_copy_in_s3_file_with_remote(run_test):
     """Test copying in s3 file
     The file should be copied into the remote context
@@ -136,7 +136,7 @@ def test_copy_in_s3_file_with_remote(run_test):
     assert b.data.startswith("s3://")
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_zero_copy_s3_file(run_test):
     """Test managed path in local file"""
     s3_resource = boto3.resource("s3", region_name="us-east-1")

--- a/tests/functional/common.py
+++ b/tests/functional/common.py
@@ -48,7 +48,7 @@ def setup():
 @pytest.fixture(autouse=False, scope="module")
 def moto_boto():
     # When you need to have moto mocked across tests.
-    with moto.mock_s3():
+    with moto.mock_aws():
         print(">>>>>>>>>>>>>>>>>>>>  MOTO UP  <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
         yield
     print(">>>>>>>>>>>>>>>>>>>> MOTO DOWN <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<")
@@ -60,7 +60,7 @@ def count() -> int:
 
 
 @pytest.fixture(scope="function")
-@moto.mock_s3
+@moto.mock_aws
 def populate_objects(run_module_test, moto_boto, count: int) -> dict:
     """Create a disdat context with count bundles.
     Return the list of UUIDs and the list of objects

--- a/tests/functional/test_add_remote.py
+++ b/tests/functional/test_add_remote.py
@@ -31,7 +31,7 @@ TEST_BUCKET_URL = "s3://{}".format(TEST_BUCKET)
 TEST_BUCKET_KEY_URL = "s3://{}/somekey".format(TEST_BUCKET)
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_add_remote():
     api.delete_context(TEST_CONTEXT)
     api.context(context_name=TEST_CONTEXT)
@@ -68,7 +68,7 @@ def test_add_remote():
     api.delete_context(TEST_CONTEXT)
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_add_remote_fail():
     error = None
     api.delete_context(TEST_CONTEXT)

--- a/tests/functional/test_link_localization.py
+++ b/tests/functional/test_link_localization.py
@@ -145,7 +145,7 @@ def _setup(remote=True):
     return s3_client
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_fast_push():
 
     s3_client = _setup()
@@ -177,7 +177,7 @@ def test_fast_push():
     api.delete_context(TEST_CONTEXT)
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_bundle_push_delocalize():
     """Test Bundle.push(delocalize)
     Test if we can push individually, and see that the files actualize to s3 paths.
@@ -210,7 +210,7 @@ def test_bundle_push_delocalize():
     api.delete_context(TEST_CONTEXT)
 
 
-@moto.mock_s3
+@moto.mock_aws
 def X_test_api_push_delocalize():
     """Test api.push(delocalize)
 
@@ -239,7 +239,7 @@ def X_test_api_push_delocalize():
     api.delete_context(TEST_CONTEXT)
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_bundle_link_localization_no_remote():
     """Test the ability to localize and delocalize individual links
     Note: you can only localize / de-localize a closed bundle.
@@ -268,7 +268,7 @@ def test_bundle_link_localization_no_remote():
     api.delete_context(TEST_CONTEXT)
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_bundle_link_localization_with_remote():
     """Test the ability to localize and delocalize individual links
     Note: you can only localize / de-localize a closed bundle.

--- a/tests/functional/test_remote.py
+++ b/tests/functional/test_remote.py
@@ -26,7 +26,7 @@ TEST_BUCKET = "test-bucket"
 TEST_BUCKET_URL = "s3://{}".format(TEST_BUCKET)
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_push(run_test):
     s3_client = boto3.client("s3")
     s3_resource = boto3.resource("s3", region_name="us-east-1")
@@ -55,7 +55,7 @@ def test_push(run_test):
     bucket.delete()
 
 
-@moto.mock_s3
+@moto.mock_aws
 def test_pull(run_test):
     s3_client = boto3.client("s3")
     s3_resource = boto3.resource("s3", region_name="us-east-1")

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = clean,py{38,39,310,311}
+envlist = clean,py{39,310,311,312,313}
 skip_missing_interpreters=true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ skip_missing_interpreters=true
 deps =
     pytest
     pytest-cov
-    moto==2.2.13
+    moto
     coverage
     pyarrow
     s3fs<=0.4.2


### PR DESCRIPTION
Support python 3.13 and update minimum python to 3.9

All tests pass locally
```
  clean: OK (0.12=setup[0.03]+cmd[0.09] seconds)
  py39: OK (14.31=setup[7.81]+cmd[4.05,2.46] seconds)
  py310: OK (10.32=setup[4.08]+cmd[4.16,2.09] seconds)
  py311: OK (9.23=setup[3.86]+cmd[3.46,1.91] seconds)
  py312: OK (11.32=setup[4.09]+cmd[4.40,2.83] seconds)
  py313: OK (9.79=setup[3.87]+cmd[3.94,1.98] seconds)
  congratulations :) (55.12 seconds)
```