### PR TITLE
chore: drop vestigial MP_CONTEXT_TYPE=fork

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,6 @@ jobs:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     env:
-      # disdat uses forked multiprocessing; pin the start method (Python 3.14
-      # defaults to forkserver on Linux).
-      MP_CONTEXT_TYPE: fork
       # moto mocks AWS; provide dummy credentials so boto3 never reaches out.
       AWS_DEFAULT_REGION: us-east-1
       AWS_ACCESS_KEY_ID: testing

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,13 +20,8 @@ pyarrow, s3fs, grpcio-tools, etc.) declared under
 ## Running the tests
 
 ```bash
-export MP_CONTEXT_TYPE=fork          # required: disdat uses multiprocessing
 .venv/bin/python -m pytest tests -q
 ```
-
-`MP_CONTEXT_TYPE=fork` is required on macOS — disdat relies on forked
-multiprocessing, and the default `spawn` start method causes the
-multiprocessing tests to hang or fail.
 
 Useful subsets:
 
@@ -52,9 +47,9 @@ contexts — your real contexts are left untouched:
 
 ## Testing across all supported Python versions
 
-`tox.ini` is configured for `py310`–`py314` (it sets `MP_CONTEXT_TYPE=fork` and
-writes an HTML coverage report). It runs whichever interpreters you have
-installed (`skip_missing_interpreters=true`):
+`tox.ini` is configured for `py310`–`py314` (and writes an HTML coverage
+report). It runs whichever interpreters you have installed
+(`skip_missing_interpreters=true`):
 
 ```bash
 uv tool run tox          # or: pipx run tox

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
     pyarrow
     s3fs>=2024.2.0
 passenv = HOME
-setenv = MP_CONTEXT_TYPE = fork
 commands =
     pytest tests/functional --disable-warnings --cov-append --cov=disdat --cov-report html
     pytest tests/bundles --disable-warnings --cov-append --cov=disdat --cov-report html


### PR DESCRIPTION
Nothing in disdat-core reads `MP_CONTEXT_TYPE` — it was only set in tox.ini and the CI workflow. The fork requirement belonged to luigi's multi-worker `apply` (unpicklable tasks under spawn), which now lives in the separate `disdatluigi` package. disdat-core has no process-based multiprocessing (S3 parallelism is `ThreadPoolExecutor`), so the platform default start method is fine.

Removes the var from `tox.ini`, `.github/workflows/test.yml`, and the CONTRIBUTING test instructions.

Verified locally: full suite (40 tests) passes under spawn (macOS default, var unset) on 3.10-3.14. This CI run additionally confirms the Linux default start methods, including forkserver on 3.14.