### PR TITLE
plan/rm-sqla: mark Phase 2 committed in PLAN_LOG

### DIFF
--- a/design_docs/plans/PLAN_LOG.md
+++ b/design_docs/plans/PLAN_LOG.md
@@ -15,4 +15,4 @@ discipline. Status advances forward only: `created` → `implemented` →
 | 6 | py314 / Phase 5: CI matrix + publish update | `design_docs/plans/py-3.10-3.14-migration.plan.md` | 2026-06-11 | 2026-06-23 | `ba826ba` | committed |
 | 7 | rm-sqla / Phase 0: plan scaffolding | `design_docs/plans/remove-sqlalchemy.plan.md` | 2026-07-13 | 2026-07-13 | `06638e5` | committed |
 | 8 | rm-sqla / Phase 1: sqlite3 layer (replace SQLAlchemy) | `design_docs/plans/remove-sqlalchemy.plan.md` | 2026-07-13 | 2026-07-14 | `8bcf618` | committed |
-| 9 | rm-sqla / Phase 2: drop sqlalchemy dependency | `design_docs/plans/remove-sqlalchemy.plan.md` | 2026-07-13 | 2026-07-14 | `3d71b6e` | implemented |
+| 9 | rm-sqla / Phase 2: drop sqlalchemy dependency | `design_docs/plans/remove-sqlalchemy.plan.md` | 2026-07-13 | 2026-07-14 | `5d7cd9f` | committed |


### PR DESCRIPTION
Bookkeeping only: advance rm-sqla Phase 2 to committed (#221 -> 5d7cd9f). All three phases done; SQLAlchemy fully removed.